### PR TITLE
0.3.0: WebSocket keepalive, four connection-lifecycle fixes, release pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
   pull_request:
+  # Lets release.yaml run this exact gate before publishing, instead of keeping a second copy of
+  # these five jobs that could drift from the real one.
+  workflow_call:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,140 @@
+name: Release
+
+# Publishes `ocpp-client` to crates.io and opens a GitHub Release.
+#
+# Normal path: push a `vX.Y.Z` tag whose version matches Cargo.toml. The tag is the trigger *and*
+# the source of truth for what gets published, so a mismatched tag fails the run rather than
+# publishing something nobody asked for.
+#
+# `workflow_dispatch` runs everything except the upload by default, so the whole pipeline can be
+# rehearsed on a branch before a tag exists.
+#
+# Only the root crate is published. The two satellite crates under `crates/` are unreleased
+# alphas that depend on `ocpp-client` by path; publishing them needs a version dependency first.
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+*"
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Actually upload to crates.io (otherwise stops after the dry run)"
+        type: boolean
+        default: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+# Two tags pushed close together must not race each other to the registry.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  # The full CI gate - fmt, clippy, test, no_std, embedded - reused rather than duplicated. A tag
+  # can be pushed at a commit CI never ran on, so this is not redundant with the CI workflow.
+  ci:
+    uses: ./.github/workflows/ci.yaml
+
+  guard:
+    name: Version and changelog guard
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Check tag, manifest and changelog agree
+        id: check
+        run: |
+          set -euo pipefail
+          version="$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[] | select(.name == "ocpp-client") | .version')"
+          echo "Cargo.toml version: $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+          if [ "${{ github.event_name }}" = "push" ]; then
+            tag="${GITHUB_REF_NAME#v}"
+            if [ "$tag" != "$version" ]; then
+              echo "::error::tag ${GITHUB_REF_NAME} does not match Cargo.toml version $version"
+              exit 1
+            fi
+          fi
+
+          if ! grep -qE "^## ${version}( |$)" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no '## ${version}' section"
+            exit 1
+          fi
+          if grep -qE "^## ${version} - unreleased" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md still marks ${version} as unreleased"
+            exit 1
+          fi
+
+      - name: Check this version is not already on crates.io
+        run: |
+          set -euo pipefail
+          version="${{ steps.check.outputs.version }}"
+          if curl -sSf -H 'User-Agent: ocpp-client-release-workflow' \
+               "https://crates.io/api/v1/crates/ocpp-client/${version}" >/dev/null 2>&1; then
+            echo "::error::ocpp-client ${version} is already published - crates.io releases are immutable"
+            exit 1
+          fi
+          echo "${version} is not published yet"
+
+  publish:
+    name: Publish to crates.io
+    needs: [ci, guard]
+    runs-on: ubuntu-latest
+    # Point this at a protected environment holding CARGO_REGISTRY_TOKEN if you want a manual
+    # approval step between "tag pushed" and "crate published".
+    environment: crates-io
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      # Builds the packaged tarball standalone, so anything that only works in the workspace
+      # (a stray path dependency, a file missing from `include`/`exclude`) fails here.
+      - name: Dry-run publish
+        run: cargo publish --dry-run
+
+      - name: Publish
+        if: github.event_name == 'push' || inputs.publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish
+
+  github-release:
+    name: GitHub Release
+    needs: [guard, publish]
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract this version's changelog section
+        run: |
+          set -euo pipefail
+          awk -v ver="${{ needs.guard.outputs.version }}" '
+            $0 ~ "^## " ver "( |$)" { inside = 1; next }
+            inside && /^## / { exit }
+            inside { print }
+          ' CHANGELOG.md > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            echo "::error::extracted empty release notes for ${{ needs.guard.outputs.version }}"
+            exit 1
+          fi
+          cat release-notes.md
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "${GITHUB_REF_NAME}" \
+            --notes-file release-notes.md \
+            --verify-tag

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ Cargo.lock
 
 .claude/
 .DS_Store
+
+# JetBrains IDE settings - editor state, not project state.
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,201 @@
+# Changelog
+
+Notable changes per release. Dates are release dates on crates.io.
+
+This file starts at 0.2.0; earlier releases (0.1.x, a per-version tokio-hardwired design that
+predates the current generic engine) are covered by git history only.
+
+## 0.3.0 - 2026-08-08
+
+### Added
+
+- **WebSocket keepalive.** The client can now ping the CSMS on a schedule and, when it stops
+  answering, force the connection to be redialled. Previously the client only ever *replied* to
+  pings the server sent, so a half-open connection - a dropped NAT entry, a mobile link that went
+  away without a FIN - was invisible: the read loop stayed parked in `recv` until the OS TCP
+  timeout, and the reconnect logic added in 0.2.0 never got a chance to fire.
+  - `KeepalivePolicy { interval, timeout, max_missed }` and `KeepaliveBehavior::{Enabled,
+    Disabled}`, shaped after the existing `ReconnectPolicy`/`ReconnectBehavior` pair.
+  - `ConnectOptions::keepalive`, **defaulting to enabled** at a 60-second interval tolerating one
+    missed pong. See "Changed" below.
+  - `Client::ping_interval()` and `Client::set_ping_interval()` - the read/write path for OCPP's
+    `OCPPCommCtrlr.WebSocketPingInterval` (2.0.1/2.1) and the 1.6 security whitepaper's
+    `WebSocketPingInterval` configuration key. Both are non-`async` so a `GetVariables` handler can
+    call them directly, and `set_ping_interval` takes effect immediately rather than after the
+    interval already being waited out expires. This is what previously forced consumers to report a
+    hardcoded `0`: the library owned no interval to report.
+  - `Client::force_reconnect()` - abandon the current transport and redial now, for callers with
+    their own liveness signal. This is what keepalive escalates to after `max_missed` unanswered
+    pings. No-op without a configured reconnector.
+  - `ClientConfig` and `Client::from_transport_with_config`, so options live in a struct instead of
+    a positional parameter list. `from_transport_with_reconnect` had already reached seven
+    arguments; keepalive would have made it eight.
+- `Client::pending_request_count()` / `Client::pending_ping_count()` behind the `test` feature -
+  instrumentation for the bookkeeping tables, since a leak in either is otherwise invisible from
+  outside.
+- `Client::is_closed()` - whether `disconnect()` has been called. Deliberately does *not* report
+  transient connection state: that would be stale the moment it returned, and `on_reconnect` is the
+  reliable way to observe reconnection.
+- **`tests/action_coverage.rs`** fails the build if `ocpp-types` defines an action that no
+  `ocpp_*_action!` invocation wires up. This is the class of gap that shipped in 0.2.0 (see below)
+  and was invisible at compile time.
+
+### Fixed
+
+- **Every timed-out request leaked an entry in the pending-response table.** `do_send_request`
+  registered a waiter keyed by message id, and the only code that removed it was the read loop on an
+  arriving CALLRESULT/CALLERROR - so a request that timed out, or that never made it onto the wire,
+  left its entry behind permanently. On a charge point running for weeks against an intermittent
+  CSMS the map grew without bound. Each request now removes its own waiter on every exit path, the
+  same fix the ping table already got.
+
+  In-flight requests are still not failed early by `disconnect()`; they wait out their timeout. That
+  is a latency wart rather than a leak, and is left as-is.
+- **Replacing a handler leaked its task.** `Client::on` (and `on_notification`) overwrote the map
+  entry for an action, which made the previous task unreachable but not finished - it stayed parked
+  forever on a channel nothing could deliver to, one leaked task per re-registration. The internal
+  channel is now closable, and the superseded handler is retired: it drains whatever was already
+  dispatched to it, answers those calls, and then exits.
+- **`wait_for` left the action registered** (`test` feature). After it returned, the action stayed
+  bound to a channel with no reader, so any later CALL for it was queued and silently forgotten -
+  the peer got no CALLRESULT and no CALLERROR, which is indistinguishable from the client hanging.
+  It now unregisters on the way out, and only if the registration is still its own.
+- **A peer that accepted the connection and then closed it immediately was redialled in a hot loop
+  with no delay at all.** `ReconnectPolicy` only delayed *failed* dials, and the attempt counter
+  reset on every successful one - so a dial that completed and then instantly dropped never waited,
+  unboundedly. Measured against a local server that completes the WebSocket handshake and drops:
+  **~9,900 connections in 2 seconds**, roughly 5k/s from a single charge point. The triggers are
+  ordinary - a CSMS rejecting the charge point at the application layer, an overloaded endpoint, a
+  load balancer with no live backend - and a fleet doing this at once is a self-inflicted DoS.
+
+  Two changes fix it. The backoff delay is now applied *before* every dial rather than only after a
+  failed one, and the attempt counter is reset by evidence that a connection actually **works** -
+  any inbound traffic on it - instead of by the mere fact that a dial completed. So a genuine
+  transient drop still reconnects after one `initial_delay`, while a connection that never carries
+  anything escalates to `max_delay` as intended.
+
+  `disconnect()` during a long backoff now also takes effect immediately instead of waiting out the
+  remaining delay (up to `max_delay`, 60s by default).
+- **Reconnect delays are now jittered** (`ReconnectPolicy::jitter`, default `true`): each delay is
+  drawn uniformly from `[delay / 2, delay]`. Without it, every charge point that lost the same CSMS
+  retried in lockstep, so the endpoint coming back got the whole fleet at once, repeatedly. Half the
+  delay is left un-jittered so a randomly tiny value can't defeat the rate bound. Randomness comes
+  from `uuid`, already a dependency and already working on this crate's bare-metal target, so no new
+  RNG dependency or embedded plumbing is involved.
+
+  One behavior change worth noting: the first redial after a drop now waits `initial_delay`
+  (jittered) where it previously went out immediately.
+- **`disconnect()` was undone by the reconnector.** Closing the transport is indistinguishable from
+  a dropped connection from the read loop's side, so with reconnect enabled - the default on
+  `ConnectOptions` - an explicit `disconnect()` produced an EOF that got dutifully redialled. On
+  default options there was no way to stop a client at all.
+
+  `disconnect()` now marks the client closed before closing the transport, and that flag is sticky
+  and outranks every automatic recovery path: the read loop exits instead of redialling (whether it
+  was parked in `recv` or saw the EOF), the keepalive task stops, `set_ping_interval` cannot restart
+  it, `force_reconnect()` becomes a no-op, and further `call`/`send_*`/`send_ping` return
+  `ClientError::Closed` immediately instead of writing to a dead transport and waiting out the
+  request timeout. `disconnect()` is also idempotent now. An *unrequested* drop is still redialled
+  exactly as before.
+
+  This also gives `ClientError::Closed` its first construction site - the variant existed but was
+  never produced by anything.
+
+### Changed
+
+- **Ping/pong now carry payloads, and pongs are matched by correlation token.** `send_ping` writes
+  an 8-byte token as the ping's application data and only a pong echoing that exact payload
+  resolves it, per RFC 6455 §5.5.2-3. Matching was previously positional, which had two failure
+  modes that a scheduled keepalive would have hit constantly:
+  - A ping that timed out left its waiter queued forever, permanently offsetting every later
+    ping's pong by one - so *every* subsequent `send_ping` on that client timed out. Reachable
+    before this release via reconnect, since the waiter table was not cleared on redial and stale
+    waiters ate the first pong of the new connection.
+  - An unsolicited pong (which RFC 6455 permits) caused the same one-off desync.
+
+  Outstanding pings are now also cleared when the read loop swaps in a reconnected transport.
+- **`ConnectOptions::default()` enables keepalive**, where the previous behavior sent no
+  unsolicited traffic. Same reasoning as `reconnect` defaulting to enabled: without keepalive a
+  charge point cannot detect a half-open link at all. Set `keepalive:
+  KeepaliveBehavior::Disabled` to restore the old behavior. The lower-level
+  `Client::from_transport*` constructors still default to **disabled** - a caller assembling a
+  client from raw transport halves has said nothing about wanting background traffic on it.
+
+### Breaking
+
+- **`rust-version = "1.87"` is now declared.** Not a change in what the crate needs, but if you
+  were building it on an older toolchain it will now fail with a clear MSRV error rather than a
+  confusing parse error. Contributors need 1.88 for the test suite (dev-dependencies).
+- `ReconnectPolicy` gained a `jitter: bool` field, which breaks struct-literal construction
+  (`ReconnectPolicy { initial_delay, max_delay, multiplier }`). Add `jitter: true` for the new
+  default behavior, `jitter: false` for exact delays, or switch to
+  `..ReconnectPolicy::default()`.
+
+The remaining changes affect implementors of the transport traits only - not callers of
+`connect_*`/`Client`. The in-tree `ocpp-transport-embassy-net` is updated accordingly.
+
+- `TransportSink::ping` and `TransportSink::pong` now take a `Vec<u8>` payload, which must be
+  transmitted verbatim (`pong` echoes the triggering ping's payload).
+- `TransportEvent::Ping` and `TransportEvent::Pong` are now `Ping(Vec<u8>)` / `Pong(Vec<u8>)`.
+- `TransportStream::recv` is now documented as having to be **cancel-safe**: its future may be
+  dropped mid-poll without losing an event. The read loop races it against the force-reconnect
+  signal, which is how a stalled `recv` gets abandoned instead of parking the loop. Both in-tree
+  implementations already satisfied this (`futures::StreamExt::next`, an `embassy-net` socket
+  read); a third-party transport buffering partial state across an `.await` in a local needs to
+  move that state into `self`.
+
+## 0.2.2 - 2026-08-08
+
+### Added
+
+- `ConnectOptions::reconnector` - lets callers decide where a dropped connection is redialled, for
+  a charge point that must move to a different CSMS address (an OCPP 2.x network connection
+  profile, a failover endpoint) without tearing down its `Client` and losing its handlers,
+  in-flight requests and queued messages.
+- Criterion benchmarks (`benches/`) plus a CI job that compiles them.
+- Community/repo health files: code of conduct, security policy, PR and issue templates.
+
+## 0.2.1 - 2026-08-06
+
+### Added
+
+- **Five actions whose types existed in `ocpp-types` but which no macro invocation had wired up**,
+  so callers could not send or receive them. If you are on 0.2.0 and believe one of these is
+  missing, upgrade - this is the release that added them:
+  - OCPP 2.0.1: `SecurityEventNotification`
+  - OCPP 2.1: `TriggerMessage`, `SetDisplayMessage`, `GetDERControl`, `SetDERControl`,
+    `UpdateDynamicSchedule`
+
+  Each has a fake-transport round-trip test. `tests/action_coverage.rs` (0.3.0, above) now
+  prevents this class of gap from recurring.
+
+### Changed
+
+- `ocpp-types` updated to 0.1.3.
+
+## 0.2.0 - 2026-08-04
+
+First release of the rewritten crate: one generic engine (`Client<E>`) shared by every OCPP
+version, replacing the previous per-version, tokio-hardwired design.
+
+### Added
+
+- OCPP 1.6, 2.0.1 and 2.1, all in `default` features.
+- Automatic reconnection with bounded exponential backoff (`ReconnectPolicy`,
+  `ReconnectBehavior`), plus `Client::on_reconnect` for post-redial session resync.
+- `no_std` + `alloc` support: the engine no longer hard-depends on tokio or `async-trait`. Task
+  spawning and timeouts go through the `Executor`/`Timer` traits; `tokio-runtime` provides the std
+  implementations.
+- Custom TLS trust config via `ConnectOptions::tls_config`, including client certificates for
+  OCPP Security Profile 3 (mutual TLS).
+- `connect()` for protocol negotiation across every compiled-in OCPP version.
+- Structured logging through `tracing` (no global subscriber is installed by this crate).
+- `SEND` (OCPP-J 2.1 message type 6) support, and `NotifyPeriodicEventStream` modeled as a
+  fire-and-forget notification rather than a call/response pair.
+- Embedded satellite crates: `ocpp-transport-embassy-net` and
+  `ocpp-board-stm32h723-nucleo`. Neither has been run against real hardware or a real CSMS yet.
+
+### Changed
+
+- Message types migrated from a `rust-ocpp` fork to `ocpp-types` on crates.io. See
+  `MIGRATION_OCPP_TYPES.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,199 +1,184 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code (claude.ai/code) working in this repository.
 
 ## Project overview
 
-`ocpp-client` is a Rust crate implementing the **charge point** (client) side of OCPP — the network/protocol
-layer only, not charging logic or hardware control. It's mid-rewrite (`1.0.0-alpha.1`) from a previous
-per-version, tokio-hardwired design (see git history before this version bump) to a single generic engine
-shared by every OCPP version, with a transport abstraction so WebSocket isn't the only option long-term.
+`ocpp-client` implements the **charge point** (client) side of OCPP — the network/protocol layer
+only, not charging logic or hardware control. Current version `0.3.0` (unreleased; 0.2.2 is the
+newest on crates.io). Pre-1.0 and still moving: 0.3.0 alone breaks `TransportSink`/`TransportStream`,
+`ReconnectPolicy`, and `ConnectOptions`' defaults.
 
-## Status: 1.6 + 2.0.1 + 2.1, WebSocket only, no_std+alloc capable
+**OCPP 1.6, 2.0.1 and 2.1** are all implemented, tested end to end, and in `default` features. Every
+action `ocpp-types` defines is wired up for every version (28 / 64 / 91) — `tests/action_coverage.rs`
+fails the build otherwise. WebSocket is the only production transport; an experimental `embassy-net`
+one lives under `crates/` (see the bottom of this file).
 
-- **OCPP 1.6, 2.0.1, and 2.1** are all implemented and tested end to end, all three in `default` features,
-  every action wired up including `NotifyReport` for 2.1 (see the `ocpp-types` bullet below - this was
-  missing until the migration documented in `MIGRATION_OCPP_TYPES.md` closed the gap). 2.1 mirrors
-  `src/ocpp_2_0_1/` exactly (`src/ocpp_2_1/{mod,error,actions}.rs`, `OCPP2_1Client`, `connect_2_1()`) -
-  `OCPP2_1Error` reuses the same RPC framework error codes as `OCPP2_0_1Error` (OCPP-J's envelope/error-code
-  set didn't change between 2.0.1 and 2.1). `Client`'s engine now supports OCPP-J 2.1's `SEND` (message
-  type 6, fire-and-forget, no CALLRESULT) alongside CALL/CALLRESULT/CALLERROR -
-  `Client::send_notification`/`Client::on_notification` in `src/client.rs`, driven by the `SendAction` trait
-  (`src/action.rs`), a sibling of `Action` for single-payload messages with no response type. 2.1's one
-  SEND-only action, `NotifyPeriodicEventStream`, is wired up via `ocpp_2_1_send_action!` in
-  `src/ocpp_2_1/actions.rs` (a sibling of `ocpp_2_1_action!`) instead of being modeled as a call/response
-  pair.
-- **WebSocket is the only transport.** The engine (`Client<E>`) is transport-agnostic via the `Transport{Sink,Stream}`
-  traits, but no second transport (e.g. an embedded framed link) exists yet.
-- **Message types come from `ocpp-types`** (crates.io, `flowionab` org, currently `0.1.1`), not the
-  earlier `rust-ocpp` fork - see `MIGRATION_OCPP_TYPES.md` for the full migration history, including a
-  real codegen bug found and fixed upstream mid-migration (0.1.0 → 0.1.1: colliding inline-enum names in
-  the 1.6 schema). `ocpp-types` is `no_std`, allocation-free by default (`heapless`-backed bounded types
-  generated from the official JSON schemas per version), with an `alloc` feature - enabled unconditionally
-  in this crate's `[dependencies]`, regardless of this crate's own `std` status - that turns
-  spec-unbounded fields into plain `alloc::String`/`Vec` instead of const-generic-sized `heapless`
-  collections. Bounded fields (e.g. `IdTag`) stay `heapless::String<N>` either way, which is the one
-  API-shape difference from the old `rust-ocpp`-based types: construction goes through fallible
-  `TryFrom`/`heapless::String::try_from(..)` rather than a bare string. `ocpp-types` has no per-version
-  cargo features (`v16`/`v201`/`v21` always compile in) - this crate's own `ocpp_1_6`/`ocpp_2_0_1`/
-  `ocpp_2_1` features just gate its own `src/ocpp_{1_6,2_0_1,2_1}/` modules, nothing to forward to.
-  Its `serde` feature derives ordinary `serde::Serialize`/`Deserialize` (ordinary enough that this crate's
-  existing `serde_json::Value`-based dynamic dispatch in `client.rs` needed no changes at all); its
-  `serde-json-core` no-alloc JSON helpers on `Action` are unused here.
-- **`no_std`+`alloc` works now.** `src/client.rs` no longer hard-depends on tokio or `async-trait`.
-  `cargo build --lib --no-default-features --features ocpp_1_6` (or `ocpp_2_0_1`) compiles the engine with
-  `std` off entirely - that's the standing proof this stays true; re-run it after touching `client.rs`,
-  `transport.rs`, `error.rs`, or either per-version `error.rs`/`actions.rs`, all of which had std-only leaks
-  (`std::error::Error`, `std::fmt`, `std::future::Future`, bare `String`/`format!`) fixed to their
-  `core`/`alloc` equivalents as part of this work.
-  - **Task spawning and timeouts are behind two small dyn-safe traits**, `Executor` and `Timer`
-    (`src/runtime.rs`), the same "boxed trait object instead of a generic parameter" trick
-    `TransportSink`/`TransportStream` already used - so `Client<E>` stays single-generic; only
-    `Client::from_transport` takes `Box<dyn Executor>`/`Box<dyn Timer>` alongside the transport. Request/ping
-    timeouts go through `runtime::with_timeout`, which races the caller's future against `Timer::delay` by
-    hand (`core::future::poll_fn`) instead of depending on `futures::select`.
-  - **`tokio-runtime` feature** (implied by `websocket`, which needs a tokio runtime for `tokio-tungstenite`
-    regardless) provides `TokioExecutor`/`TokioTimer`, the impls `connect_1_6`/`connect_2_0_1` and this
-    crate's own tests use. Embedded users disable it and supply their own `Executor`/`Timer` (e.g. backed by
-    `embassy-executor`/`embassy-time`).
-  - **Internal `Mutex`/oneshot/mpsc/broadcast replacements live in `src/sync.rs`**, built on
-    `embassy-sync`'s `Mutex`/`Signal` fixed to `CriticalSectionRawMutex` (works under std via
-    `critical-section`'s `std` backend, gated by our `std` feature; embedded targets must register their own
-    backend via `critical_section::set_impl!`, standard embassy convention). The request-dispatch queue
-    (`Chan`) is now unbounded (backed by `alloc::collections::VecDeque`) instead of the old fixed-capacity
-    `mpsc::channel(1000)`, and the ping fan-out (`BroadcastRegistry`) gives each subscriber a single-slot
-    `Signal` rather than tokio broadcast's buffered channel - a slow `on_ping` subscriber sees only the
-    latest ping, not a backlog, which is fine for a low-frequency keepalive.
-  - Diagnostics in `client.rs` go through the `tracing` crate (`tracing::warn!`/`error!`/`info!`), not a bare
-    `eprintln!` - `tracing` itself is `#![no_std]` and used unconditionally (not gated behind our `std`
-    feature), so these events fire the same way under `no_std`+`alloc` too. Our `std` feature forwards to
-    `tracing/std` (thread-local dispatch instead of tracing's no_std global-only dispatch); either way, no
-    events go anywhere unless the *application* installs a `tracing::Subscriber` (e.g. `tracing-subscriber`'s
-    `fmt` layer on std, or a `defmt`/RTT-backed one on embedded) - this crate only emits events, it never
-    installs a global subscriber itself. See `tests/ocpp_1_6_logging.rs` for how to capture them in a test
-    (`tracing-test` with its `no-env-filter` feature - required because `tests/*.rs` files are each their own
-    crate, so `tracing-test`'s default per-crate env filter would otherwise filter out `ocpp_client`'s own
-    events).
-  - True bare-metal no_std (no `alloc`) is still out of scope - the engine's `BTreeMap`/`VecDeque`/`Arc`-based
-    bookkeeping is alloc-dependent by design. `ocpp-types` itself supports no_std+no_alloc (its `alloc`
-    feature is opt-in, not required), but this crate always enables it - see the `ocpp-types` bullet above.
+Message types come from **`ocpp-types`** (crates.io, `flowionab` org, currently `0.1.3`) — see
+`MIGRATION_OCPP_TYPES.md` for the migration off the old `rust-ocpp` fork. It's `no_std` and
+allocation-free by default; this crate enables its `alloc` feature unconditionally, so
+spec-unbounded fields are plain `String`/`Vec`. Bounded fields (e.g. `IdTag`) stay
+`heapless::String<N>` either way, so construction goes through fallible `TryFrom`. `ocpp-types` has
+no per-version cargo features; this crate's `ocpp_1_6`/`ocpp_2_0_1`/`ocpp_2_1` features only gate its
+own modules.
 
 ## Architecture
 
 ### One generic engine, not one implementation per version
 
-`src/client.rs` defines `Client<E: ProtocolError>` — the entire CALL/RESULT/ERROR dispatch, timeout, and
-pending-request bookkeeping, written **once** and shared by every OCPP version. `OCPP1_6Client` (in
-`src/ocpp_1_6/mod.rs`) and `OCPP2_0_1Client` (in `src/ocpp_2_0_1/mod.rs`) are both just
-`pub type ..Client = Client<..Error>;` — no duplicated client struct per version like the old design had.
-Porting 2.0.1 required zero changes to `client.rs`/`error.rs`/`envelope.rs`/`transport.rs`, which is the
-proof this design does what it was meant to.
+`src/client.rs` defines `Client<E: ProtocolError>` — the entire CALL/RESULT/ERROR dispatch, timeout
+and bookkeeping, written **once**. `OCPP1_6Client`/`OCPP2_0_1Client`/`OCPP2_1Client` are just
+`pub type ..Client = Client<..Error>;`. Porting 2.0.1 and 2.1 required zero changes to
+`client.rs`/`error.rs`/`envelope.rs`/`transport.rs`, which is the proof this design does its job.
 
-- `src/error.rs` — `ProtocolError` trait (implemented once per version by that version's error enum: `code()`,
-  `description()`, `details()`, `not_implemented()`, `from_wire()`) and `ClientError<E>`, the flattened error
-  type (`Protocol(E)`, `Timeout`, `Decode(...)`, `Transport(...)`, `Closed`) replacing the old
-  `Result<Result<Response, VersionError>, Box<dyn Error>>` double-nesting.
-- `src/envelope.rs` — `RawCall`/`RawResult`/`RawError` tuple structs mirroring the OCPP-J wire arrays
-  (`[MessageTypeId, UniqueId, Action, Payload]` etc.). Shared across all versions (the envelope shape is
-  identical regardless of OCPP version) instead of duplicated per version.
-- `src/action.rs` — the `Action` trait: `const NAME`, `type Request`, `type Response`. One marker type per
-  OCPP action implements this (e.g. `ocpp_1_6::Heartbeat`). This is also the "custom message extension" path:
-  implement `Action` for your own type (including one with vendor fields via `#[serde(flatten)]`) to send/
-  receive it through the exact same `Client::call`/`Client::on` used for standard actions.
-- `src/transport.rs` — `TransportSink`/`TransportStream` traits (dyn-safe via `async-trait`): send/receive one
-  whole OCPP-J frame at a time, plus a `TransportEvent::{Frame,Ping,Pong}` so WebSocket-level keepalive can
-  flow through without the generic engine knowing anything WebSocket-specific. `src/transport/websocket.rs`
-  (feature `websocket`) is the only implementation today, wrapping a split `tokio-tungstenite` stream.
-- `src/connect.rs` (feature `websocket`) — `connect_1_6()` does the WS handshake + protocol negotiation and
-  builds a `Client` via `Client::from_transport(sink, stream, timeout)`. That constructor is `pub` precisely so
-  tests (and eventually a non-WebSocket transport) can build a client over anything implementing the two
-  transport traits, without needing a real socket — see `tests/common/mod.rs`'s in-memory fake transport.
+- `src/error.rs` — the `ProtocolError` trait (implemented once per version) and `ClientError<E>`
+  (`Protocol`/`Timeout`/`Decode`/`Transport`/`Closed`).
+- `src/envelope.rs` — `RawCall`/`RawResult`/`RawError`/`RawSend` tuple structs mirroring the OCPP-J
+  wire arrays. Shared by all versions; the envelope shape doesn't differ between them.
+- `src/action.rs` — the `Action` trait (`const NAME`, `type Request`, `type Response`) and its
+  single-payload sibling `SendAction` for OCPP-J 2.1 `SEND` (message type 6, fire-and-forget). This
+  is also the custom-message extension path: implement `Action` for your own type (vendor fields via
+  `#[serde(flatten)]`) and it goes through the same `Client::call`/`Client::on`.
+- `src/transport.rs` — `TransportSink`/`TransportStream`, dyn-safe via hand-written boxed futures
+  (**not** the `async-trait` crate, which is deliberately not a dependency), plus
+  `TransportEvent::{Frame, Ping(Vec<u8>), Pong(Vec<u8>)}`. `src/transport/websocket.rs` (feature
+  `websocket`) wraps a split `tokio-tungstenite` stream.
+- `src/keepalive.rs` — `KeepalivePolicy`/`KeepaliveBehavior`, deliberately shaped like
+  `src/reconnect.rs`'s policy/behavior pair. The loop itself is `keepalive_loop` in `client.rs`.
+- `src/runtime.rs` — `Executor`/`Timer` traits plus `with_timeout`/`with_cancel`, both hand-rolled
+  `poll_fn` races (no `futures::select` dependency). `runtime/tokio.rs` has the std impls.
+- `src/sync.rs` — `SharedMutex`/`OneShot`/`Chan`/`Notify`/`BroadcastRegistry`, replacing the tokio
+  primitives `client.rs` used to need. Built on `embassy-sync` fixed to `CriticalSectionRawMutex`.
+- `src/connect.rs` (feature `websocket`) — `connect_1_6`/`_2_0_1`/`_2_1`/`connect` do the handshake
+  and protocol negotiation, then build a `Client` via
+  `Client::from_transport_with_config(sink, stream, executor, timer, config)`. Options live in
+  `ClientConfig`, not a positional list; the older `from_transport`/`from_transport_with_reconnect`
+  remain as thin wrappers. `ConnectOptions::default()` enables reconnect **and** keepalive, while
+  `ClientConfig::new` enables neither — the convenience path opts in, the raw-transport path stays
+  inert.
+
+### Invariants that are easy to break
+
+These each cost a real bug once. Read them before touching `client.rs`.
+
+- **Every bookkeeping entry must be removed by whoever added it, on every exit path.** `Client` keeps
+  four tables (`pending_responses`, `pong_waiters`, `request_senders`, `notification_senders`). The
+  read loop only removes an entry when a *response arrives*, so any path that gives up — timeout,
+  transport send failure — must clean up itself or the table grows forever. `do_send_request` and
+  `send_ping_with_timeout` have each shipped this bug once. `tests/ocpp_1_6_bookkeeping.rs` guards
+  both via the `test`-gated `pending_request_count`/`pending_ping_count` accessors; add a case there
+  when you add a table.
+- **Retiring a handler means closing its channel, not just dropping the map entry.** `on`/
+  `on_notification` spawn a task parked on a `Chan`; overwriting the registration alone leaves that
+  task alive forever. `Chan::close` ends it, and drains first so the outgoing handler still answers
+  calls already dispatched to it. `wait_for` likewise removes its own registration on return, guarded
+  by `Chan::is_same`.
+- **Pongs are matched by correlation token, not arrival order.** Pings carry an 8-byte token as
+  payload and `PongState` keys outstanding pings by it. Positional matching meant one timed-out or
+  unsolicited pong desynced every later ping permanently. Transports must therefore carry ping/pong
+  payloads verbatim (RFC 6455 requires a pong to echo the ping's).
+- **The read loop has three distinct exit paths** — `LoopExit::{Eof, Forced, Shutdown}` — and
+  collapsing them is a bug. `Eof` redials if configured; `Forced` (keepalive gave up, or
+  `force_reconnect`) redials after a bounded courtesy close; `Shutdown` (`disconnect()`, via a sticky
+  `closed: AtomicBool`) exits without redialling. `closed` also short-circuits the keepalive loop,
+  `set_ping_interval`, `force_reconnect` and every send path (which return `ClientError::Closed`).
+  Anything new reacting to the connection ending must check it.
+- **`recv` is raced against the wake signal unconditionally**, so `disconnect()` can pull the loop
+  out of a parked `recv`. That's why `TransportStream::recv`'s cancel-safety contract is
+  unconditional too.
+- **Reconnect backoff escalates on "this connection never worked", not "the dial failed".**
+  `attempt` lives across connections and resets *only* when inbound traffic arrives — never on a dial
+  merely completing, which is what made an accept-then-immediately-close peer a zero-delay hot loop
+  (~5k dials/s, measured). The delay applies *before* every dial for the same reason.
+  `ReconnectPolicy::jitter` (default on) spreads delays over `[d/2, d]` so a fleet doesn't retry in
+  lockstep. Keep both halves: escalation must not punish a connection that genuinely worked.
+- **`no_std` + `alloc` must keep compiling.** `client.rs`, `transport.rs`, `error.rs`, `runtime.rs`,
+  `sync.rs` and the per-version files have all leaked `std` before (`std::error::Error`, `std::fmt`,
+  bare `String`/`format!`). Re-run the three proof builds after touching any of them. Diagnostics go
+  through `tracing` (itself `#![no_std]`, used unconditionally); this crate never installs a
+  subscriber. `tests/ocpp_1_6_logging.rs` shows how to capture events in a test — it needs
+  `tracing-test`'s `no-env-filter` feature, since each `tests/*.rs` is its own crate.
+- True bare-metal `no_std` (no `alloc`) is out of scope: the engine's `BTreeMap`/`VecDeque`/`Arc`
+  bookkeeping is alloc-dependent by design. See PRODUCTION_READINESS.md item 9.
 
 ### Per-version modules
 
-`src/ocpp_1_6/` is the template for every version:
-- `error.rs` — the version's `ProtocolError` impl. Written with one `macro_rules!` (`define_error!`) listing
-  `Variant => "WireCode"` pairs once, instead of hand-writing `code()`/`description()`/`details()`/`from_wire()`
-  match arms per variant.
-- `actions.rs` — one `ocpp_1_6_action!(Name, Request, Response, "ActionName", send_x, on_x, wait_for_x)` macro
-  invocation per OCPP action. Each expands to: an `Action` marker type, and `send_x`/`on_x`/`wait_for_x`
-  methods on `OCPP1_6Client` that just call the generic `Client::call`/`Client::on`/`Client::wait_for`. This
-  is the resolution of the earlier "ergonomic API" design discussion: callers get named, autocomplete-friendly
-  methods (not `client.call::<Heartbeat>(...)` turbofish), but adding an action is one macro line, not three
-  hand-written method bodies.
-- `mod.rs` — re-exports plus the `OCPP1_6Client` type alias.
+`src/ocpp_1_6/` is the template:
+- `error.rs` — that version's `ProtocolError` impl, written with one `macro_rules!`
+  (`define_error!`) listing `Variant => "WireCode"` pairs, not hand-written match arms.
+- `actions.rs` — one `ocpp_1_6_action!(Name, Request, Response, "ActionName", send_x, on_x,
+  wait_for_x)` per action, expanding to the marker type plus the three methods. Adding an action is
+  one macro line, but callers still get named, autocomplete-friendly methods.
+- `mod.rs` — re-exports plus the `OCPP1_6Client` alias.
 
-### Adding a new OCPP action to 1.6
+### Adding an action
 
-Add one `ocpp_1_6_action!(...)` line in `src/ocpp_1_6/actions.rs` with the action's `ocpp_types::v16`
-request/response types. Write the test first (a `tests/ocpp_1_6_fake_transport.rs`-style test is enough; no
-need for a real WebSocket round-trip per action - one real-transport test already covers that wiring).
-
-### Adding a new OCPP action to 2.0.1/2.1
-
-Same as 1.6: add one `ocpp_2_0_1_action!(...)`/`ocpp_2_1_action!(...)` line in the matching `actions.rs`
-with the action's `ocpp_types::v201`/`ocpp_types::v21` request/response types. Nested enum/field types
-(e.g. `ResetRequestType`, or a version's `RpcErrorCode`) live under that version's `common` submodule, not
-re-exported at the version root - only the top-level Request/Response structs are. Action name string = the
-struct name minus its `Request`/`Response` suffix; `send_x`/`on_x`/`wait_for_x` method names are the
-snake_case of that same name (the existing invocations in each file are the reference for edge cases like
-acronym runs - `Get15118EVCertificate` → `get_15118_ev_certificate`, `ClearDERControl` →
-`clear_der_control`). Write the test first, same TDD rule as every other version.
+Add one `ocpp_{1_6,2_0_1,2_1}_action!(...)` line in that version's `actions.rs` with the
+`ocpp_types::{v16,v201,v21}` request/response types. **Write the test first.** Nested enum/field
+types live under that version's `common` submodule, not the version root. The action name string is
+the struct name minus its `Request`/`Response` suffix; method names are its snake_case (existing
+invocations are the reference for acronym runs — `Get15118EVCertificate` →
+`get_15118_ev_certificate`, `ClearDERControl` → `clear_der_control`). 2.1's SEND-only
+`NotifyPeriodicEventStream` uses `ocpp_2_1_send_action!` instead, since it has no response type.
 
 ## TDD is mandatory
 
-Every behavior added so far has a test in `tests/`. Two styles, both expected going forward, mirrored per
-version (`ocpp_1_6_*` / `ocpp_2_0_1_*` / `ocpp_2_1_*`):
+Every behavior has a test in `tests/`. Two styles, mirrored per version:
 
-- **Fake-transport tests** (`tests/ocpp_1_6_fake_transport.rs`, `tests/ocpp_2_0_1_fake_transport.rs`,
-  `tests/ocpp_2_1_fake_transport.rs`) — drive a real `Client` over the in-memory transport in
-  `tests/common/mod.rs`. Fast, no networking, and the right default for anything about dispatch, timeouts, or
+- **Fake-transport** (`tests/ocpp_{1_6,2_0_1,2_1}_fake_transport.rs`) — drive a real `Client` over
+  the in-memory transport in `tests/common/mod.rs`. The right default for dispatch, timeouts and
   error propagation.
-- **Real-transport tests** (`tests/ocpp_1_6_websocket.rs`, `tests/ocpp_2_0_1_websocket.rs`,
-  `tests/ocpp_2_1_websocket.rs`) — a real `tokio-tungstenite` server task plus
-  `connect_1_6`/`connect_2_0_1`/`connect_2_1`, to prove the actual transport wiring works. One of these per
-  version+transport combination is enough; don't duplicate every action-level test against a real socket.
-- `wait_for_*` tests (`tests/ocpp_1_6_wait_for.rs`) need `#![cfg(feature = "test")]` at the top of the file and
-  must be run with `cargo test --features test` — they're invisible to a plain `cargo test`.
+- **Real-transport** (`tests/ocpp_{1_6,2_0_1,2_1}_websocket.rs`) — a real `tokio-tungstenite` server
+  plus `connect_*`. One per version+transport is enough; don't duplicate action-level tests over a
+  real socket.
+
+Tests needing the `test` feature (`wait_for_*`, bookkeeping) are invisible to a plain `cargo test`;
+run `cargo test --features test`.
+
+Three suites don't fit either style and aren't mirrored per version:
+- `tests/action_coverage.rs` — locates the `ocpp-types` source via `cargo metadata`, reads the
+  `const ACTION` from each `*_request.rs`, and fails if any action lacks a macro invocation. Guards
+  the gap that shipped in 0.2.0 (five actions with types present but no wrapper). If `ocpp-types`
+  changes its one-file-per-type layout, this is what breaks.
+- `tests/ocpp_1_6_keepalive.rs` / `_websocket_keepalive.rs` — ping/pong and scheduled keepalive.
+  Version-independent, so 1.6 only. Millisecond intervals with generous `timeout(..)` bounds rather
+  than a mock clock; the real-socket file exists to prove a real peer echoes ping payloads.
+- `tests/ocpp_1_6_bookkeeping.rs` / `_disconnect.rs` / `_reconnect_backoff.rs` — the invariants
+  above. Each case was confirmed to fail against the unfixed code; keep that property.
 
 ## Common commands
 
-This repo is a Cargo **workspace** (root `Cargo.toml` has `[workspace]` + `[package]` both -
-`ocpp-client` is itself a member). `default-members = ["."]`, so a plain `cargo build`/`test`/etc.
-at the root only ever touches `ocpp-client` - exactly like before the workspace existed. The two
-satellite crates under `crates/` (`ocpp-transport-embassy-net`, `ocpp-board-stm32h723-nucleo` -
-see "Embedded satellite crates" below) are never implicitly included; always pass `-p <crate>` to
-touch them. (Passing `--workspace` bypasses `default-members` and builds everything, including
-`ocpp-board-stm32h723-nucleo` - that fails on a non-ARM host, since it depends on `cortex-m`'s
-inline `asm!`. Don't use `--workspace` here unless you also pass `--target thumbv7em-none-eabihf`.)
+This repo is a Cargo **workspace** whose root is also the `ocpp-client` package.
+`default-members = ["."]`, so a plain `cargo build`/`test` only touches `ocpp-client`. The two
+satellite crates under `crates/` need an explicit `-p`. Don't use `--workspace` without
+`--target thumbv7em-none-eabihf` — `ocpp-board-stm32h723-nucleo` depends on `cortex-m`'s inline
+`asm!` and won't build for the host.
 
 ```sh
-cargo build                              # default features: std, tokio-runtime, websocket, ocpp_1_6, ocpp_2_0_1, ocpp_2_1
-cargo test                                # run all tests
-cargo test <test_name>                    # run a single test by name (substring match)
-cargo test --features test                # also run the wait_for_* tests
-cargo build --no-default-features --features std,ocpp_1_6   # core + 1.6, no tokio/WebSocket pulled in
-cargo build --lib --no-default-features --features ocpp_1_6 # no_std+alloc proof (no --target needed - lib-only, no binary to link)
-cargo fmt                                 # format (rustfmt, per CONTRIBUTING.md)
+cargo build                                   # default: std, tokio-runtime, websocket, all three versions
+cargo test --features test                    # all tests, including the test-gated ones
+cargo test <name>                             # single test, substring match
+cargo fmt                                     # rustfmt, per CONTRIBUTING.md
+cargo build --no-default-features --features std,ocpp_1_6      # core + 1.6, no tokio/WebSocket
+cargo build --lib --no-default-features --features ocpp_1_6    # no_std+alloc proof (lib-only, no --target needed)
 ```
 
-CI (`.github/workflows/ci.yaml`) runs four jobs on push-to-`main` and every pull request: `fmt`
-(`cargo fmt --all -- --check`), `clippy` (`cargo clippy --all-targets --all-features -- -D
-warnings`), `test` (`cargo build` then `cargo test --features test`, covering the `wait_for_*`
-tests too), `no_std` (the three `cargo build -p ocpp-client --lib --no-default-features --features
-ocpp_{1_6,2_0_1,2_1}` proof builds), and `embedded` (checks/clippies
-`ocpp-transport-embassy-net` and full-links `ocpp-board-stm32h723-nucleo` against the real
-`thumbv7em-none-eabihf` target, with `RUSTFLAGS: --cfg getrandom_backend="custom"` - see that
-crate's README for why). Keep all five green.
+MSRV is **1.87** for the library (bound by `heapless` via `ocpp-types`); the test suite needs 1.88
+for dev-dependencies. Verify with `cargo +1.87 check --lib --all-features`.
+
+CI (`.github/workflows/ci.yaml`) runs five jobs on push-to-`main` and every PR: `fmt`, `clippy`
+(`--all-targets --all-features -D warnings`), `test` (`cargo build` then
+`cargo test --features test`), `no_std` (the three lib-only proof builds), and `embedded`
+(checks/clippies `ocpp-transport-embassy-net` and full-links `ocpp-board-stm32h723-nucleo` against
+the real `thumbv7em-none-eabihf` target, with `RUSTFLAGS: --cfg getrandom_backend="custom"`). Keep
+all five green — the `embedded` job in particular catches dead code that host builds don't.
 
 ## Embedded satellite crates
 
 `crates/ocpp-transport-embassy-net` (chip-agnostic `no_std`+`alloc` WebSocket transport over
-`embassy-net`) and `crates/ocpp-board-stm32h723-nucleo` (NUCLEO-H723ZG firmware scaffold wiring
-that transport to real Ethernet hardware) are the embedded story from PRODUCTION_READINESS.md
-item 6. Both are real code (compile, and for the board crate, fully link, against
-`thumbv7em-none-eabihf`) but **neither has been run against real hardware or a real CSMS yet** -
-see each crate's own README for exact status, the two `ocpp-client`-relevant gaps their
-existence surfaced (`getrandom` needs a custom backend on bare-metal targets; embassy's
-`Spawner`/`Stack` are `!Sync` where `ocpp_client::Executor`/`Reconnector` require `Send + Sync`),
-and next steps.
+`embassy-net`) and `crates/ocpp-board-stm32h723-nucleo` (NUCLEO-H723ZG firmware scaffold) are
+PRODUCTION_READINESS.md item 6. Both compile — and the board crate fully links — against
+`thumbv7em-none-eabihf`, but **neither has been run against real hardware or a real CSMS**, and the
+transport has no TLS. Each crate's README states its exact status and the two `ocpp-client`-relevant
+gaps their existence surfaced: `getrandom` needs a custom backend on bare-metal targets, and
+embassy's `Spawner`/`Stack` are `!Sync` where `Executor`/`Reconnector` require `Send + Sync`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,30 @@ default-members = ["."]
 [package]
 edition = '2024'
 name = "ocpp-client"
-version = "0.2.2"
+version = "0.3.0"
 description = "OCPP Client Implementation. Use this library to implement an OCPP charge point"
 repository = "https://github.com/flowionab/ocpp-client"
+documentation = "https://docs.rs/ocpp-client"
+readme = "README.md"
 license = "MIT OR Apache-2.0"
 authors = ["Joatin Granlund <joatin@granlund.io>"]
-keywords = ["OCPP", "ChargePoint", "Client", "ocpp16", "ocpp201"]
+# crates.io allows at most five.
+keywords = ["ocpp", "charge-point", "ocpp16", "ocpp201", "ocpp21"]
+categories = ["network-programming", "embedded", "no-std"]
+# What a *consumer* needs to build the library. Verified empirically with
+# `cargo +1.87 check --lib --all-features`; the binding constraint is `heapless` 0.9 (via
+# ocpp-types), not this crate's own code. Building the test suite needs 1.88 - the `rcgen`/`time`
+# dev-dependencies and a let-chain in tests/ - but that only affects contributors, not users.
+rust-version = "1.87"
+# Keep editor and CI scaffolding out of the published tarball. `.idea/` was shipping inside the
+# crate up to 0.2.2.
+exclude = [".idea/", ".github/", ".editorconfig"]
+
+# docs.rs builds only default features unless told otherwise, which would hide the `test`-gated
+# helpers (`wait_for`, the pending-count accessors) from the rendered docs even though they are
+# public API.
+[package.metadata.docs.rs]
+all-features = true
 
 [features]
 default = ["std", "tokio-runtime", "websocket", "ocpp_1_6", "ocpp_2_0_1", "ocpp_2_1"]

--- a/KEEPALIVE_ROADMAP.md
+++ b/KEEPALIVE_ROADMAP.md
@@ -1,0 +1,227 @@
+# Roadmap: WebSocket keepalive / ping interval
+
+> **Status: all five phases implemented.** See CHANGELOG.md's Unreleased section for the shipped
+> surface. Deviations from the plan below, all noted in place: phase 0's `MockTimer` was dropped in
+> favour of millisecond intervals with generous bounds (simpler, and the tests are deterministic
+> without it); phase 5's coverage check turned out to be exactly implementable via `cargo metadata`
+> plus `ocpp-types`' `const ACTION`, rather than the "optional but cheap" approximation expected
+> here. Kept as the record of why the work is shaped the way it is.
+
+Triage and plan for three gaps reported by a downstream agent consuming `ocpp-client 0.2.1`. The
+short version: **one of the three is real, two were already fixed in 0.2.1 itself** and the
+reporter was almost certainly reading 0.2.0. That mis-triage is itself worth an action item, so
+it's tracked below as item 5.
+
+## Triage
+
+| # | Report | Verdict |
+|---|--------|---------|
+| 1 | No ping-interval on `ConnectOptions`; transport only replies to pings | **Real.** Confirmed at HEAD (0.2.2) |
+| 2 | Four 2.1 actions never generated (`GetDERControl`, `SetDERControl`, `SetDisplayMessage`, `UpdateDynamicSchedule`) | **Already fixed.** Shipped in 0.2.1 |
+| 3 | `SecurityEventNotification` missing for 2.0.1 | **Already fixed.** Shipped in 0.2.1 |
+
+### Why 2 and 3 are already closed
+
+Commit `2c93e83` "Wire up six action wrappers already supported by ocpp-types 0.1.2" is an
+*ancestor* of `70449f4` "Bump to 0.2.1" — it added exactly these five actions (plus 2.1
+`TriggerMessage`). Verified three ways:
+
+- `git show 70449f4:src/ocpp_2_1/actions.rs` contains all four 2.1 macro invocations
+  (lines 395, 813, 822, 930), and `70449f4:src/ocpp_2_0_1/actions.rs` line 526 has
+  `SecurityEventNotification`.
+- The **published** 0.2.1 tarball from `static.crates.io` contains the same — 91
+  `ocpp_2_1_action!` invocations, all five present.
+- The published **0.2.0** tarball has 86 invocations and is missing all five.
+
+So the reporter's environment was on 0.2.0 while believing it was 0.2.1. The available methods
+today are `send_get_der_control` / `send_set_der_control` / `send_set_display_message` /
+`send_update_dynamic_schedule` / `send_security_event_notification`, each with matching
+`on_*` and `wait_for_*`.
+
+**Action:** tell the consumer to bump to `0.2.2` and re-check. No library work needed for their
+B6, B8.2, B2.6 or F4.4 items. (Their plan IDs — A4, B6, B8.2, B2.6, F4.4 — aren't resolvable from
+this repo; the mapping above is by feature, not by ID.)
+
+## The real gap: no client-initiated keepalive
+
+Current state, all verified in source:
+
+- `Client::send_ping()` (`src/client.rs:311`) sends **one** ping and awaits a pong, bounded by
+  `self.timeout`. It's manual — nothing calls it on a schedule.
+- `Client::on_ping()` (`src/client.rs:327`) observes *inbound* pings. The read loop auto-pongs
+  every inbound `TransportEvent::Ping` (`src/client.rs:136`).
+- `ConnectOptions` (`src/connect.rs:19`) has `username`/`password`/`timeout`/`reconnect`/
+  `tls_config`/`reconnector`. No ping interval, and no getter to report one.
+- Consequence: a dead-but-not-closed TCP connection is never detected. The read loop only leaves
+  its inner loop when `recv()` returns `Ok(None)`/`Err(_)`, so a half-open socket parks there
+  until the OS TCP timeout — the reconnect machinery added in 0.2.x never fires.
+
+So the reporter's "`WebSocketPingInterval` reads 0, which is the honest answer" is exactly right:
+there is nothing to report because the library doesn't own an interval.
+
+### Two latent bugs this work must fix first
+
+Both are pre-existing and currently near-unreachable because nothing pings on a timer. An
+automatic keepalive loop makes both live, so they are prerequisites, not follow-ups.
+
+**(a) Timed-out pings permanently desync the pong FIFO.** `send_ping` pushes a `OneShot` onto
+`pong_waiters` and then races `waiter.wait()` against the timeout. On timeout it returns
+`Err(Timeout)` **without removing its own waiter**, and the read loop's `Pong` arm only ever
+`pop_front()`s. So once a pong is genuinely never delivered, the deque is offset by one forever:
+the next pong signals the stale waiter, that ping times out too, and so on. Every subsequent
+`send_ping` on that client fails. Reachable today via reconnect — `pong_waiters` is not cleared
+when the read loop swaps in a new transport, so stale waiters survive the redial and eat the
+first pong of the new connection.
+
+**(b) Ping/pong are uncorrelated.** `WebSocketSink::ping` sends an empty payload
+(`src/transport/websocket.rs:33`) and `TransportEvent::Pong` carries none, so matching is purely
+positional. An unsolicited pong from the peer (permitted by RFC 6455) causes the same one-off
+desync as (a). Exact fix is `ping(payload)` + `TransportEvent::Pong(Vec<u8>)` and matching on the
+echoed payload — a breaking change to the two transport traits, and the only way to make
+correlation actually correct.
+
+### Zero test coverage today
+
+`grep -rn ping tests/` hits only the fake transport's own `ping`/`pong` impls. There is no test
+for `send_ping`, `on_ping`, or auto-pong. Per CLAUDE.md's mandatory-TDD rule, scaffolding comes
+before behavior.
+
+The harness is *nearly* ready: `tests/common/mod.rs`'s `FakeSink::ping` forwards a `Ping` event to
+the peer end, and the peer's read loop auto-pongs — so a loopback pair produces real pongs, and a
+test holding the peer's `FakeSource` can assert `TransportEvent::Ping` arrives. What's missing is a
+controllable clock; see phase 0.
+
+## Plan
+
+Five phases, each independently shippable and each landing with tests. Sizes are relative, not
+calendar estimates.
+
+### Phase 0 — Test scaffolding (small)
+
+- Add a `MockTimer` to `tests/common/mod.rs`: an `ocpp_client::Timer` impl whose `delay` resolves
+  only when the test advances it, so interval scheduling can be asserted exactly rather than
+  slept through. Without it every keepalive test pays real wall-clock time and turns flaky under
+  CI load.
+- Add the missing baseline tests for existing behavior: `send_ping` resolves on pong, times out
+  without one, and the read loop auto-pongs an inbound ping.
+- Add the two **failing** regression tests for bugs (a) and (b), so phase 1 has a red bar to turn
+  green.
+
+### Phase 1 — Fix pong correlation (small, unblocks everything)
+
+- Remove the caller's own waiter from `pong_waiters` on the timeout path.
+- Clear `pong_waiters` when the read loop swaps in a reconnected transport (same place
+  `read_sink` is replaced, `src/client.rs:159`).
+- Decide on payload correlation (see Decisions). If yes, this is the moment to change
+  `TransportSink::ping` and `TransportEvent::Pong` — before a keepalive loop depends on the
+  current shape.
+
+### Phase 2 — Keepalive in the engine (medium)
+
+Belongs in `Client<E>`, not in the WebSocket connect path: the transport traits already carry
+`ping`/`pong`, so `ocpp-transport-embassy-net` and any future framed transport get keepalive for
+free. It also survives reconnects for free — `send_ping` goes through `self.sink`, which the read
+loop swaps in place, so a task spawned once keeps working across redials.
+
+- New `src/keepalive.rs`, mirroring `src/reconnect.rs`'s shape:
+  `KeepalivePolicy { interval, timeout: Option<Duration>, max_missed: u32 }` plus
+  `KeepaliveBehavior::{Enabled(KeepalivePolicy), Disabled}`.
+- Interval state is shared and mutable — `Arc<SharedMutex<Option<Duration>>>` on `Client` — so
+  the value can be changed at runtime (phase 4) rather than frozen at construction.
+- The loop itself needs no new sync primitive. `runtime::with_timeout(timer, interval,
+  config_changed.wait())` is already exactly "sleep for `interval`, but wake early if
+  signalled": `Err(Elapsed)` means tick, `Ok(())` means the interval was reconfigured. Reuse it
+  instead of adding a `with_cancel`.
+- `interval == 0` means disabled, matching how OCPP's `WebSocketPingInterval` reads.
+
+Constructor pressure is the design problem here. `from_transport_with_reconnect` already takes
+seven arguments and both constructors are public API; keepalive would make it eight and a third
+constructor would make the set unmaintainable. Introduce
+`ClientConfig { timeout, reconnector, reconnect_policy, keepalive }` and
+`Client::from_transport_with_config(sink, stream, executor, timer, config)`, then reduce both
+existing constructors to thin wrappers over it. Non-breaking, and it stops the parameter
+explosion before the next option arrives.
+
+### Phase 3 — Dead-peer detection (medium; this is what gives keepalive teeth)
+
+Detecting a dead link is the whole point — logging a missed pong is not enough. After
+`max_missed` consecutive misses, force a redial through the existing reconnect path.
+
+There's no mechanism for that today, and the obvious one is insufficient:
+
+- **Cooperative close alone won't do it.** Calling `sink.close()` from the keepalive task makes
+  tungstenite emit a Close frame, and on a merely-idle socket the read half then returns
+  `Ok(None)` and the reconnect path runs. But on a genuinely dead TCP link — the case keepalive
+  exists to catch — that frame never lands and `recv()` stays parked. It's still worth doing so
+  the peer sees a clean close when the link *is* alive, just not sufficient.
+- **Recommended: race the read loop against a force-reconnect signal.** Have the read loop poll
+  `stream.recv()` against a `Signal` using the same hand-rolled `poll_fn` pattern as
+  `with_timeout`, and have the keepalive task fire that signal. Robust regardless of socket
+  state, and no new dependency.
+  - This makes cancel-safety a **contract** on `TransportStream::recv`: the future may be dropped
+    mid-poll without losing a frame. Both current implementors already satisfy it
+    (`StreamExt::next()` and tokio `mpsc::recv` are cancel-safe), but it must be documented on
+    the trait, since third-party transports now have to honor it.
+  - Wrap the `sink.close()` courtesy call in `with_timeout` so a dead socket can't hang the
+    keepalive task.
+- Emit `tracing` events on each miss and on the forced redial, consistent with the existing
+  reconnect logging.
+
+### Phase 4 — Expose it for device-model reporting (small)
+
+This is what actually unblocks the reporter's A4. The library should own the interval and expose
+it; it should **not** grow a device model — that belongs in the layer above (`ocpp-charge-point`).
+
+- `Client::ping_interval() -> Option<Duration>` so a `GetVariables`/`GetConfiguration` handler can
+  report the live value instead of hardcoding 0.
+- `Client::set_ping_interval(Option<Duration>)` so a CSMS `SetVariables` on
+  `OCPPCommCtrlr.WebSocketPingInterval` can take effect without tearing down the client. Signals
+  the config-changed `Signal` from phase 2 so the running loop re-reads it immediately rather
+  than after the current sleep expires.
+- `ConnectOptions::keepalive: KeepaliveBehavior`, threaded through `connect_1_6` / `connect_2_0_1`
+  / `connect_2_1` / `connect`. Add it to the redacting `Debug` impl (`src/connect.rs:57`).
+- README: document the mapping to 2.x `OCPPCommCtrlr.WebSocketPingInterval` and the 1.6 security
+  whitepaper's `WebSocketPingInterval` config key, so consumers wire the variable to the getter
+  rather than reinventing a timer.
+
+### Phase 5 — Make capability-vs-version legible (small)
+
+The 0.2.0-reported-as-0.2.1 confusion cost a downstream consumer real planning effort, and the
+repo currently gives them no way to check a claim like "action X is missing" against a version.
+
+- Add a `CHANGELOG.md`. There is none, and `2c93e83`'s five new actions are invisible to anyone
+  not reading git log.
+- Have the README's protocol section state which version wired up which actions, or point at the
+  changelog. It currently mentions none of the five by name.
+- Optional but cheap: a test that asserts every action name in the relevant `ocpp-types` version
+  module has a macro invocation, so "types exist but the wrapper doesn't" becomes a CI failure
+  instead of a downstream bug report.
+
+## Decisions needed
+
+1. **Default for `ConnectOptions::keepalive`.** `ReconnectBehavior` defaults to `Enabled` on the
+   reasoning that production charge points should keep retrying; the same argument applies to
+   keepalive on NAT'd or mobile links, and a default of `Disabled` means most consumers never get
+   dead-peer detection. Against: it changes on-wire behavior for existing 0.2.x users.
+   *Recommendation:* `Enabled` at a conservative interval (60s), documented in the changelog as a
+   behavior change. Pre-1.0 is the right time to take it.
+2. **Payload correlation now or later (phase 1).** Doing it now is a breaking change to
+   `TransportSink::ping` and `TransportEvent::Pong`, which ripples into
+   `ocpp-transport-embassy-net` and `tests/common`. Doing it later means a second breaking change
+   after consumers have adopted keepalive. *Recommendation:* now, in the same release as the
+   `ClientConfig` change, so there's one breaking release rather than two.
+3. **Fixed interval vs idle-reset.** A fixed interval is the straightforward reading of
+   `WebSocketPingInterval`. Resetting the timer on any inbound traffic saves pings on a busy link
+   but is more machinery and arguably less spec-literal. *Recommendation:* fixed interval;
+   revisit only if a real deployment complains.
+
+## Sequencing
+
+Phases 0 → 1 → 2 → 3 land in order (each depends on its predecessor). Phase 4 depends on 2 but
+not 3, so it can ship as soon as the loop exists — worth doing, since the getter/setter is the
+part the downstream consumer is actually blocked on. Phase 5 is independent of all of them and can
+go first; it's the cheapest item here and prevents a repeat of this triage.
+
+CI must stay green throughout — including the three `no_std` proof builds, since phases 1–3 all
+touch `client.rs` and `transport.rs`, both of which are on the `no_std` path, and the `embedded`
+job builds `ocpp-transport-embassy-net` against the real transport traits that phase 1 may change.

--- a/PRODUCTION_READINESS.md
+++ b/PRODUCTION_READINESS.md
@@ -2,6 +2,12 @@
 
 Gaps to close before pointing real hardware/fleets at this crate, in priority order.
 
+**Scope note.** The core crate over its WebSocket transport has been exercised against a real
+CSMS. The remaining "not run against a real CSMS / real hardware" caveats below and in the
+per-crate READMEs are specifically about the **embedded** satellite crates
+(`ocpp-transport-embassy-net`, `ocpp-board-stm32h723-nucleo`) - don't read them as applying to
+`ocpp-client` itself.
+
 1. ~~**No reconnection logic.**~~ **Done.** `Client<E>`'s background read loop now takes an
    optional `Reconnector` (`src/reconnect.rs`) plus a `ReconnectPolicy` (bounded exponential
    backoff, unlimited attempts) via `Client::from_transport_with_reconnect`. `connect_1_6` /
@@ -61,12 +67,20 @@ Gaps to close before pointing real hardware/fleets at this crate, in priority or
    and `::on_notify_periodic_event_stream_fires_and_never_sends_a_reply`, the latter also
    asserting the client never auto-replies to a received SEND.
 
-5. **Versioning/release.** Crate is `0.2.0-alpha.1`. The git-fork dependency blocker is gone -
-   `ocpp-types` is a real crates.io release (`0.1.1`), not a git dependency, so that specific
-   `cargo publish` obstacle no longer applies. `ocpp-types` itself is early (`0.1.x`, same org as
-   the old `rust-ocpp` fork - see `MIGRATION_OCPP_TYPES.md`'s Risk section for a codegen bug
-   found and fixed upstream mid-migration), so pin it deliberately rather than assuming API
-   stability. API here is still alpha-stability regardless.
+5. **Versioning/release.** Crate is `0.3.0` (unreleased; 0.2.2 is the newest on crates.io). The
+   git-fork dependency blocker is long gone - `ocpp-types` is a real crates.io release (`0.1.3`),
+   not a git dependency. `ocpp-types` itself is still early (`0.1.x`, same org as the old
+   `rust-ocpp` fork - see `MIGRATION_OCPP_TYPES.md`'s Risk section for a codegen bug found and
+   fixed upstream mid-migration), so pin it deliberately rather than assuming API stability. This
+   crate's own API is pre-1.0 and still moving: 0.3.0 alone carries breaking changes to
+   `TransportSink`/`TransportStream`, `ReconnectPolicy`, and `ConnectOptions`' defaults.
+
+   Release metadata was tidied at the same time: `rust-version = "1.87"` (verified with
+   `cargo +1.87 check --lib --all-features`; the binding constraint is `heapless` 0.9 via
+   `ocpp-types`, and building the *test suite* needs 1.88 for dev-dependencies), plus
+   `categories`, `readme`, `documentation`, a `keywords` list that finally mentions 2.1, and an
+   `exclude` that keeps `.idea/`/`.github/` out of the published tarball - `.idea/` had been
+   shipping inside the crate through 0.2.2, and was also purged from git history.
 
 6. ~~**README overclaims embedded transport support.**~~ **Done.** It advertised "STM32-compatible
    transport layer" / "STM32 transport: ✅ Supported," but only the WebSocket transport
@@ -195,3 +209,129 @@ Gaps to close before pointing real hardware/fleets at this crate, in priority or
    itself requires `Send`). Relax the transport bound alone and the default tokio/std build stops
    compiling - fixing it properly means reworking `Executor::spawn`'s `Send` bound too, which is really
    part of the same generic-parameter redesign as the rest of this item, not a separate one.
+
+10. ~~**No client-initiated keepalive, and no `WebSocketPingInterval` to report.**~~ **Done.** The
+    client only ever *replied* to pings the CSMS sent (`Client::send_ping` existed but nothing called
+    it on a schedule), so a half-open connection - a dropped NAT entry, a mobile link gone without a
+    FIN - was undetectable: the read loop stayed parked in `TransportStream::recv` until the OS TCP
+    timeout, and the reconnect machinery from item 1 never got a chance to fire. Downstream consumers
+    also had no interval to report for `OCPPCommCtrlr.WebSocketPingInterval` (2.0.1/2.1) or the 1.6
+    security whitepaper's `WebSocketPingInterval` key, and were hardcoding `0`.
+
+    `src/keepalive.rs` now holds `KeepalivePolicy`/`KeepaliveBehavior` (shaped like item 1's
+    `ReconnectPolicy`/`ReconnectBehavior`), with the loop in `client.rs`. It lives in the engine, not
+    the WebSocket transport, so `ocpp-transport-embassy-net` gets it for free. `ConnectOptions`
+    defaults it to **enabled** at 60s tolerating one missed pong; `ClientConfig::new` (the
+    raw-transport path) defaults to disabled. After `max_missed` unanswered pings the loop calls
+    `Client::force_reconnect`, which the read loop honors only when a reconnector is configured -
+    otherwise dropping the connection would leave a permanently deaf client, strictly worse than an
+    unanswered ping. `Client::ping_interval`/`set_ping_interval` are the non-`async` read/write path
+    for the spec variable, and a write applies immediately instead of after the interval already being
+    waited out.
+
+    Two latent bugs had to be fixed first, both near-unreachable while pings were only ever manual and
+    both routine once a timer sends them: pongs were matched to pings **positionally**, so (a) a ping
+    that timed out left its waiter queued forever and permanently offset every later ping's pong by
+    one - poisoning every subsequent `send_ping` on that client, reachable via reconnect since the
+    waiter table wasn't cleared on redial - and (b) an unsolicited pong (legal per RFC 6455) caused the
+    same desync. Pings now carry an 8-byte correlation token as their payload and only a pong echoing
+    it resolves them, which is why `TransportSink::ping`/`pong` and `TransportEvent::Ping`/`Pong` grew
+    `Vec<u8>` payloads (breaking, for transport implementors only). Racing `recv` against the
+    force-reconnect signal also makes cancel-safety a documented contract on `TransportStream::recv`.
+
+11. ~~**Nothing caught actions whose types existed but were never wired up.**~~ **Done.** Five actions
+    shipped in 0.2.0 with `ocpp-types` request/response types present but no `ocpp_*_action!`
+    invocation, so callers had no way to send or receive them; it surfaced only as a downstream bug
+    report, and was fixed in 0.2.1. Nothing about it was visible at compile time - an unwired type is
+    just an unreferenced one. `tests/action_coverage.rs` now locates the `ocpp-types` source via
+    `cargo metadata`, reads the `const ACTION` string out of each `*_request.rs`, and fails the build
+    naming any action with no matching macro invocation. All three versions are fully covered today
+    (28 / 64 / 91). The repo also gained a `CHANGELOG.md` - it had none, so which release added which
+    action was invisible to anyone not reading git log, which is what let the original report be filed
+    against the wrong version.
+
+12. ~~**`disconnect()` raced the reconnector.**~~ **Done.** Closing the transport looks exactly like
+    a dropped connection from the read loop's side, so with reconnect enabled (the default on
+    `ConnectOptions` since item 1) an explicit `disconnect()` produced an EOF the reconnector
+    redialled - meaning on default options there was no way to stop a client at all. `Client` now
+    carries a sticky `closed` flag that `disconnect()` sets *before* closing the transport, and that
+    outranks every automatic recovery path: the read loop exits rather than redialling (whether it
+    was parked in `recv` or saw the EOF), the keepalive task returns, `set_ping_interval` can't
+    restart it, `force_reconnect()` is a no-op, and further sends fail fast with
+    `ClientError::Closed` - the first construction site that variant has ever had. `LoopExit`
+    (`Eof`/`Forced`/`Shutdown`) is what makes the read loop's three exit paths distinguishable
+    instead of all collapsing into "connection ended, redial". Covered by
+    `tests/ocpp_1_6_disconnect.rs`, whose real-socket case is the one that actually reproduced the
+    race - the in-memory fake's `close()` doesn't end the peer's stream, so the fake never produced
+    the EOF that triggered the redial.
+
+    Racing `recv` against the wake signal is now unconditional (it used to be armed only when a
+    reconnector existed), so `disconnect()` can pull the read loop out of a `recv` that would
+    otherwise park until the OS TCP timeout. That is why `TransportStream::recv`'s cancel-safety
+    contract applies to every transport, not just ones used with reconnect.
+
+13. ~~**Successful-connect-then-immediate-EOF was a hot reconnect loop.**~~ **Done.**
+    `ReconnectPolicy` only delayed *failed* connect attempts, and `attempt` reset to `0` on every
+    success - so a peer that accepts the connection and then closes it immediately (a CSMS rejecting
+    the charge point at the application layer, an overloaded or misconfigured endpoint, a load
+    balancer with no live backend) got redialled with no delay at all, unboundedly. Measured against
+    a local server that completes the WebSocket handshake and drops: **~9,900 connections in 2
+    seconds**, i.e. ~5k/s sustained from a single charge point. A charge point behaving that way
+    against a real CSMS is a self-inflicted DoS, and the fleet-wide version is worse.
+
+    Surfaced while testing item 12 and confirmed independently against the fixed code, so it was
+    neither caused nor fixed by that change.
+
+    The fix keeps "reconnect promptly when the link genuinely comes back" - the behavior worth
+    keeping - by separating *a dial completed* from *a connection works*: `attempt` now lives across
+    connections and is reset only by inbound traffic arriving on one (`attempt = 0` in the read
+    loop's inbound-event arm), never by a dial merely succeeding. The delay also moved to *before*
+    each dial rather than only after a failed one, since the old ordering meant a
+    succeed-then-instantly-drop cycle never waited at all. A connection that carries traffic
+    therefore still costs exactly one `initial_delay` on its next drop, while one that never carries
+    anything escalates to `max_delay`.
+
+    `ReconnectPolicy::jitter` (new, default `true`) spreads each delay uniformly over
+    `[delay / 2, delay]`, because a fleet that all lost the same CSMS previously retried in lockstep
+    and hit it as a thundering herd on recovery. Half the delay stays un-jittered so a randomly tiny
+    value can't defeat the rate bound. Randomness comes from a throwaway v4 UUID - `uuid` is already
+    a dependency for message ids and its RNG already works on `thumbv7em-none-eabihf`, so this
+    needed no new dependency and no new embedded plumbing; the arithmetic is integer-only to avoid
+    a float dependency on no-FPU targets.
+
+    Two knock-on behavior changes, both documented in CHANGELOG.md: the first redial after a drop
+    now waits `initial_delay` (jittered) instead of going out immediately, and `disconnect()` during
+    a backoff no longer has to wait out the remaining delay. Covered by
+    `tests/ocpp_1_6_reconnect_backoff.rs`; three of its four cases fail against the old logic, the
+    fourth being the guard against over-correcting (escalation must not punish a connection that
+    genuinely worked).
+
+14. ~~**Unbounded bookkeeping growth and leaked handler tasks.**~~ **Done.** Three leaks in the same
+    family, all invisible from outside the crate - they show up only as memory growth on a charge
+    point that has been up for weeks:
+
+    - **`pending_responses` leaked on every timed-out request.** `do_send_request` inserted a waiter
+      keyed by message id and only `handle_frame` ever removed one, on an arriving
+      CALLRESULT/CALLERROR. A request that timed out - or that failed to reach the wire at all -
+      left its entry forever. Each request now cleans up after itself on every exit path. This is
+      the identical failure the pong table had (item 10); fixing that one and not this one was an
+      oversight, and both tables are now covered by the same suite so neither regresses alone.
+    - **`Client::on`/`on_notification` leaked a task per re-registration.** Overwriting the map entry
+      made the previous handler unreachable but not finished - it stayed parked forever on a channel
+      nothing could deliver to. `Chan` (`src/sync.rs`) gained `close()`, and the superseded handler
+      is retired: it drains what was already dispatched to it, answers those calls, then exits.
+      Draining before stopping is deliberate - dropping the queue would leave a peer with no reply.
+    - **`wait_for` never unregistered** (`test` feature). The action stayed bound to a reader-less
+      channel, so a later CALL for it was queued and silently forgotten: no CALLRESULT, no CALLERROR,
+      indistinguishable from a hung client. It now removes its registration on the way out, and only
+      when that registration is still its own.
+
+    Covered by `tests/ocpp_1_6_bookkeeping.rs`, using two new `test`-feature accessors
+    (`pending_request_count`, `pending_ping_count`) and a drop-detecting callback to prove a retired
+    task actually ended. Each case was confirmed to fail against the unfixed code.
+
+    Still open in this area, deliberately: `disconnect()` does not fail *in-flight* requests early -
+    they wait out their timeout rather than returning `Closed` immediately. That is latency, not a
+    leak. Doing it properly means either changing what the pending-response channel carries or
+    racing each waiter against a connection-generation signal, and neither is worth the complexity
+    until something needs it.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The library handles the complexities of establishing and managing OCPP connectio
 
 OCPP message types and protocol definitions are provided by [`ocpp-types`](https://github.com/flowionab/ocpp-types), while OCPP Client focuses on the communication layer required to exchange messages between charge points and Charge Station Management Systems (CSMS).
 
-Designed for both cloud/server environments and resource-constrained embedded systems, OCPP Client supports standard WebSocket connections as well as `no_std` compatible transports for STM32-based platforms.
+Designed for both cloud/server environments and resource-constrained embedded systems, OCPP Client speaks WebSocket out of the box and compiles for `no_std` + `alloc` targets. An `embassy-net`-based transport and an STM32 board scaffold ship alongside it as **experimental** crates - see [Supported Transports](#-supported-transports).
 
 The library currently supports **OCPP 1.6J**, **OCPP 2.0.1**, and **OCPP 2.1**.
 
@@ -39,8 +39,9 @@ The library currently supports **OCPP 1.6J**, **OCPP 2.0.1**, and **OCPP 2.1**.
 * ⚡ OCPP **2.1 support**
 * 🌐 WebSocket transport
 * 🔒 Secure WebSocket (WSS)
-* 🔋 STM32-compatible transport layer
+* 🔋 `embassy-net` transport for embedded targets (experimental)
 * 🔄 Connection lifecycle management
+* 💓 Scheduled WebSocket keepalive with dead-peer detection
 * 📨 Message routing
 * 🧩 Transport abstraction
 * 🪶 Lightweight runtime
@@ -51,21 +52,34 @@ The library currently supports **OCPP 1.6J**, **OCPP 2.0.1**, and **OCPP 2.1**.
 
 ## 🔌 Supported Protocols
 
-| Protocol   | Status         |
-| ---------- | -------------- |
-| OCPP 1.6J  | ✅ Supported    |
-| OCPP 2.0.1 | ✅ Supported    |
-| OCPP 2.1   | ✅ Supported    |
+| Protocol   | Status         | Actions wired up |
+| ---------- | -------------- | ---------------- |
+| OCPP 1.6J  | ✅ Supported    | all 28           |
+| OCPP 2.0.1 | ✅ Supported    | all 64           |
+| OCPP 2.1   | ✅ Supported    | all 91           |
+
+Every action defined by [`ocpp-types`](https://crates.io/crates/ocpp-types) for each version has a
+`send_*`/`on_*` method - `tests/action_coverage.rs` fails the build otherwise, so the table can't
+drift. If a method you expect is missing, check [CHANGELOG.md](CHANGELOG.md) before filing an
+issue: five actions were only wired up in **0.2.1**, so a 0.2.0 build is missing
+`SecurityEventNotification` (2.0.1) and `TriggerMessage`, `SetDisplayMessage`, `GetDERControl`,
+`SetDERControl`, `UpdateDynamicSchedule` (2.1).
 
 ---
 
 ## 🌐 Supported Transports
 
-| Transport              | Status      |
-| ---------------------- | ----------- |
-| WebSocket              | ✅ Supported |
-| Secure WebSocket (WSS) | ✅ Supported |
-| STM32 transport        | ✅ Supported |
+| Transport                                   | Status            |
+| ------------------------------------------- | ----------------- |
+| WebSocket                                    | ✅ Supported       |
+| Secure WebSocket (WSS), incl. mutual TLS     | ✅ Supported       |
+| `embassy-net` (embedded, `no_std` + `alloc`) | 🧪 Experimental   |
+
+The embedded transport (`crates/ocpp-transport-embassy-net`) and the NUCLEO-H723ZG firmware
+scaffold (`crates/ocpp-board-stm32h723-nucleo`) compile and fully link against the real
+`thumbv7em-none-eabihf` target in CI, but **neither has been run against real hardware or a real
+CSMS**, and the embedded transport has no TLS. Treat them as a starting point for a board bring-up
+rather than a supported deployment path. Each crate's README states its exact status.
 
 ---
 
@@ -87,7 +101,7 @@ For embedded targets or `no_std` environments:
 ocpp-client = { version = "0.x", default-features = false }
 ```
 
-This allows the same OCPP communication foundation to run on resource-constrained devices such as STM32 microcontrollers while still supporting traditional server-side applications.
+This lets the same OCPP communication core compile for resource-constrained devices as well as server-side applications. Embedded users supply their own `Executor`/`Timer` implementations (e.g. backed by `embassy-executor`/`embassy-time`) and a `critical-section` backend for their target.
 
 ---
 
@@ -234,18 +248,62 @@ ocpp-client = "0.x"
 ## 🚀 Quick Example
 
 ```rust
-use ocpp_client::Client;
+use ocpp_client::connect_1_6;
+use ocpp_client::ocpp_types::v16::HeartbeatRequest;
 
 #[tokio::main]
 async fn main() {
-    let client = Client::new();
+    // `None` takes the defaults: 5s request timeout, automatic reconnect, and keepalive
+    // pinging every 60s.
+    let client = connect_1_6("wss://example.com/ocpp", None).await.unwrap();
 
-    client
-        .connect("wss://example.com/ocpp")
-        .await
-        .unwrap();
+    let response = client.send_heartbeat(HeartbeatRequest {}).await.unwrap();
+    println!("CSMS time: {}", response.current_time);
 }
 ```
+
+Use `connect_2_0_1`/`connect_2_1` for those versions, or `connect` to negotiate whichever version
+the server picks.
+
+---
+
+## 💓 Keepalive & `WebSocketPingInterval`
+
+By default a client pings the CSMS every 60 seconds and, after two unanswered pings, drops the
+connection and redials. Without this a half-open link - a dropped NAT entry, a mobile connection
+that vanished without a FIN - is undetectable: the socket accepts writes and nothing ever comes
+back, and reconnect can't help because nothing reports the connection as closed.
+
+```rust
+use ocpp_client::{ConnectOptions, KeepaliveBehavior, KeepalivePolicy, connect_1_6};
+use std::time::Duration;
+
+let options = ConnectOptions {
+    keepalive: KeepaliveBehavior::Enabled(KeepalivePolicy {
+        interval: Duration::from_secs(30),
+        timeout: None,          // fall back to the client's request timeout
+        max_missed: 2,
+    }),
+    ..Default::default()
+};
+let client = connect_1_6("wss://example.com/ocpp", Some(options)).await?;
+```
+
+Set `keepalive: KeepaliveBehavior::Disabled` if the CSMS pings the charge point instead, or if the
+deployment forbids unsolicited traffic.
+
+This crate does not implement a device model, but it owns the ping timer, so it exposes the value
+for the layer that does:
+
+| OCPP | Variable / key | Read | Write |
+| ---- | -------------- | ---- | ----- |
+| 2.0.1 / 2.1 | `OCPPCommCtrlr.WebSocketPingInterval` (`GetVariables`/`SetVariables`) | `client.ping_interval()` | `client.set_ping_interval(..)` |
+| 1.6 (security whitepaper) | `WebSocketPingInterval` (`GetConfiguration`/`ChangeConfiguration`) | `client.ping_interval()` | `client.set_ping_interval(..)` |
+
+Both are non-`async`, so a `GetVariables` handler can call them directly. `None` maps to the
+spec's `0` (disabled) in both directions, writes take effect immediately rather than after the
+current interval finishes, and a write can enable pinging on a client that started with keepalive
+disabled.
 
 ---
 

--- a/benches/call_roundtrip.rs
+++ b/benches/call_roundtrip.rs
@@ -33,12 +33,14 @@ impl TransportSink for FakeSink {
 
     fn ping<'a>(
         &'a mut self,
+        _payload: Vec<u8>,
     ) -> Pin<Box<dyn Future<Output = Result<(), TransportError>> + Send + 'a>> {
         Box::pin(async move { Ok(()) })
     }
 
     fn pong<'a>(
         &'a mut self,
+        _payload: Vec<u8>,
     ) -> Pin<Box<dyn Future<Output = Result<(), TransportError>> + Send + 'a>> {
         Box::pin(async move { Ok(()) })
     }

--- a/crates/ocpp-transport-embassy-net/README.md
+++ b/crates/ocpp-transport-embassy-net/README.md
@@ -39,8 +39,13 @@ solid starting point to iterate on with a real server, not a finished implementa
   transport effectively relies on tungstenite to paper over. Most peers tear down the TCP
   connection shortly after sending Close regardless, so this is unlikely to matter in practice,
   but it's not spec-perfect.
-- **Empty-payload pong.** Matches `ocpp-client`'s own WebSocket transport
-  (`src/transport/websocket.rs`) - neither echoes the triggering ping's payload today.
+- **Ping/pong payloads are carried verbatim** (they used to be dropped, sending empty control
+  frames). `ocpp-client`'s keepalive puts an 8-byte correlation token in each ping and matches the
+  pong that echoes it, so discarding the payload here would make every scheduled ping look
+  unanswered - and after `KeepalivePolicy::max_missed` of those, redial a perfectly healthy
+  connection. Inbound pings are answered with the triggering ping's payload, per RFC 6455 §5.5.3.
+  Control-frame payloads are capped at 125 bytes by the spec, so they always arrive whole in
+  `frame_buf` - no accumulation needed, unlike text frames.
 - **Reads/writes go through a single shared `Mutex<WebSocketClient<..>>`** for the encode/decode
   state machine (continuation-frame tracking, RNG for masking), while the actual socket I/O uses
   independent `TcpReader`/`TcpWriter` halves with no lock between them - so a concurrent

--- a/crates/ocpp-transport-embassy-net/src/transport.rs
+++ b/crates/ocpp-transport-embassy-net/src/transport.rs
@@ -285,14 +285,17 @@ impl TransportSink for EmbassyWsSink {
 
     fn ping<'a>(
         &'a mut self,
+        payload: Vec<u8>,
     ) -> Pin<Box<dyn Future<Output = Result<(), TransportError>> + Send + 'a>> {
+        // The payload carries `Client`'s correlation token; it has to go out verbatim or the
+        // pong that echoes it back can't be matched to the ping that asked for it.
         Box::pin(AssertSendFuture(async move {
             let len = {
                 let mut ws = self.ws.lock().await;
                 ws.write(
                     WebSocketSendMessageType::Ping,
                     true,
-                    &[],
+                    &payload,
                     &mut self.tx_scratch,
                 )
                 .map_err(boxed_error)?
@@ -307,16 +310,17 @@ impl TransportSink for EmbassyWsSink {
 
     fn pong<'a>(
         &'a mut self,
+        payload: Vec<u8>,
     ) -> Pin<Box<dyn Future<Output = Result<(), TransportError>> + Send + 'a>> {
-        // Empty-payload pong, matching ocpp-client's own tokio-tungstenite-based transport
-        // (src/transport/websocket.rs) - neither echoes the triggering ping's payload today.
+        // Echoes the triggering ping's payload, as RFC 6455 §5.5.3 requires - `Client`'s read
+        // loop hands it straight through from the `TransportEvent::Ping` it is replying to.
         Box::pin(AssertSendFuture(async move {
             let len = {
                 let mut ws = self.ws.lock().await;
                 ws.write(
                     WebSocketSendMessageType::Pong,
                     true,
-                    &[],
+                    &payload,
                     &mut self.tx_scratch,
                 )
                 .map_err(boxed_error)?
@@ -414,8 +418,18 @@ impl TransportStream for EmbassyWsStream {
                             "ocpp-transport-embassy-net: dropping unexpected binary frame"
                         );
                     }
-                    WebSocketReceiveMessageType::Ping => return Ok(Some(TransportEvent::Ping)),
-                    WebSocketReceiveMessageType::Pong => return Ok(Some(TransportEvent::Pong)),
+                    // Control-frame payloads are capped at 125 bytes by RFC 6455, so these always
+                    // arrive whole in `frame_buf` - no accumulation needed, unlike Text.
+                    WebSocketReceiveMessageType::Ping => {
+                        return Ok(Some(TransportEvent::Ping(
+                            self.frame_buf[..ws_result.len_to].to_vec(),
+                        )));
+                    }
+                    WebSocketReceiveMessageType::Pong => {
+                        return Ok(Some(TransportEvent::Pong(
+                            self.frame_buf[..ws_result.len_to].to_vec(),
+                        )));
+                    }
                     WebSocketReceiveMessageType::CloseMustReply
                     | WebSocketReceiveMessageType::CloseCompleted => {
                         // Simplified close handling: no close-reply frame is sent back (see

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,17 +4,20 @@ use crate::envelope::{
     RawError, RawResult, RawSend,
 };
 use crate::error::{ClientError, ProtocolError};
+use crate::keepalive::{KeepaliveBehavior, KeepalivePolicy};
 use crate::reconnect::{ReconnectPolicy, Reconnector};
-use crate::runtime::{Executor, Timer, with_timeout};
-use crate::sync::{BroadcastRegistry, Chan, OneShot, SharedMutex};
+use crate::runtime::{Executor, Timer, with_cancel, with_timeout};
+use crate::sync::{BroadcastRegistry, Chan, Notify, OneShot, SharedMutex};
 use crate::transport::{TransportEvent, TransportSink, TransportStream};
 use alloc::borrow::ToOwned;
 use alloc::boxed::Box;
-use alloc::collections::{BTreeMap, VecDeque};
+use alloc::collections::BTreeMap;
 use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::sync::Arc;
+use alloc::vec::Vec;
 use core::future::Future;
+use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use core::time::Duration;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -24,7 +27,113 @@ use uuid::Uuid;
 type PendingResponses<E> = Arc<SharedMutex<BTreeMap<Uuid, OneShot<Result<Value, E>>>>>;
 type RequestSenders = Arc<SharedMutex<BTreeMap<String, Chan<(String, Value)>>>>;
 type NotificationSenders = Arc<SharedMutex<BTreeMap<String, Chan<Value>>>>;
-type PongWaiters = Arc<SharedMutex<VecDeque<OneShot<()>>>>;
+type PongWaiters = Arc<SharedMutex<PongState>>;
+
+/// Outstanding pings, keyed by the correlation token written into each ping's payload. RFC 6455
+/// requires a pong to echo that payload back, so a pong resolves the exact ping that produced it
+/// rather than whichever one happened to be at the front of a queue.
+///
+/// This replaced a `VecDeque<OneShot<()>>` matched positionally, which had two failure modes: a
+/// ping that timed out left its waiter in the queue forever, permanently offsetting every later
+/// ping's pong by one, and an unsolicited pong (which RFC 6455 permits) did the same. Both were
+/// mostly unreachable while pings were only ever sent by hand; a keepalive loop pinging on a
+/// timer makes them routine.
+#[derive(Default)]
+struct PongState {
+    next_token: u64,
+    waiters: BTreeMap<u64, OneShot<()>>,
+}
+
+/// Why the read loop stopped reading the current transport, which decides what happens next.
+enum LoopExit {
+    /// The transport ended or errored on its own. Redial if a reconnector is configured.
+    Eof,
+    /// Keepalive (or `Client::force_reconnect`) gave up on an unresponsive peer. Redial.
+    Forced,
+    /// `Client::disconnect` was called. Stop entirely - do not redial.
+    Shutdown,
+}
+
+/// The keepalive interval, mutable at runtime so a CSMS writing `WebSocketPingInterval` takes
+/// effect on a live connection, plus the fixed policy governing each ping.
+///
+/// Stored as milliseconds in an `AtomicU32` rather than behind the client's mutex so
+/// `Client::ping_interval`/`set_ping_interval` can stay non-`async` - a `GetVariables` handler
+/// reporting the value shouldn't have to await a lock. `u32` milliseconds caps at ~49 days, far
+/// beyond any sane ping interval, and 32-bit atomics exist on every target this crate builds for
+/// (`AtomicU64` does not - notably not on `thumbv7em-none-eabihf`).
+struct KeepaliveState {
+    interval_millis: AtomicU32,
+    changed: Notify,
+    policy: KeepalivePolicy,
+}
+
+impl KeepaliveState {
+    /// The current interval, or `None` when keepalive is off. Zero is the disabled
+    /// representation, matching OCPP's `WebSocketPingInterval` semantics.
+    fn interval(&self) -> Option<Duration> {
+        match self.interval_millis.load(Ordering::Relaxed) {
+            0 => None,
+            millis => Some(Duration::from_millis(millis as u64)),
+        }
+    }
+
+    fn set_interval(&self, interval: Option<Duration>) {
+        let millis = interval
+            .map(|d| d.as_millis().min(u32::MAX as u128) as u32)
+            .unwrap_or(0);
+        self.interval_millis.store(millis, Ordering::Relaxed);
+        self.changed.notify();
+    }
+}
+
+/// Everything `Client::from_transport_with_config` needs beyond the transport halves and the
+/// runtime. Introduced because the option set had outgrown positional parameters -
+/// `from_transport_with_reconnect` already took seven arguments, and keepalive would have made it
+/// eight or forced a third constructor.
+///
+/// Defaults are deliberately inert: no reconnector, no keepalive. `ConnectOptions` (the
+/// WebSocket convenience path) opts into both, but a caller assembling a client from raw
+/// transport halves gets exactly the behavior they asked for and nothing more.
+pub struct ClientConfig {
+    /// How long to wait for a CALLRESULT/CALLERROR, and the default pong deadline.
+    pub timeout: Duration,
+    /// Redials when the transport closes. `None` means the read loop exits on disconnect.
+    pub reconnector: Option<Box<dyn Reconnector>>,
+    /// Backoff between failed reconnect attempts. Ignored when `reconnector` is `None`.
+    pub reconnect_policy: ReconnectPolicy,
+    /// Whether to ping the peer on a schedule, and what to do when it stops answering.
+    pub keepalive: KeepaliveBehavior,
+}
+
+impl ClientConfig {
+    /// A config with `timeout` and nothing else enabled.
+    pub fn new(timeout: Duration) -> Self {
+        Self {
+            timeout,
+            reconnector: None,
+            reconnect_policy: ReconnectPolicy::default(),
+            keepalive: KeepaliveBehavior::Disabled,
+        }
+    }
+
+    /// Redial through `reconnector`, backing off per `policy`, when the transport closes.
+    pub fn with_reconnect(
+        mut self,
+        reconnector: Box<dyn Reconnector>,
+        policy: ReconnectPolicy,
+    ) -> Self {
+        self.reconnector = Some(reconnector);
+        self.reconnect_policy = policy;
+        self
+    }
+
+    /// Ping the peer per `keepalive`.
+    pub fn with_keepalive(mut self, keepalive: KeepaliveBehavior) -> Self {
+        self.keepalive = keepalive;
+        self
+    }
+}
 
 /// The OCPP client engine, generic over one version's protocol error type. `OCPP1_6Client`
 /// and `OCPP2_0_1Client` are just `Client<OCPP1_6Error>` / `Client<OCPP2_0_1Error>` - the
@@ -37,6 +146,11 @@ pub struct Client<E: ProtocolError> {
     pong_waiters: PongWaiters,
     ping_registry: Arc<BroadcastRegistry>,
     reconnect_registry: Arc<BroadcastRegistry>,
+    keepalive: Arc<KeepaliveState>,
+    force_reconnect: Notify,
+    /// Sticky: set by `disconnect()` and never cleared. Distinguishes "the caller shut this
+    /// client down" from "the connection dropped", which the read loop must treat oppositely.
+    closed: Arc<AtomicBool>,
     executor: Arc<dyn Executor>,
     timer: Arc<dyn Timer>,
     timeout: Duration,
@@ -52,6 +166,9 @@ impl<E: ProtocolError> Clone for Client<E> {
             pong_waiters: self.pong_waiters.clone(),
             ping_registry: self.ping_registry.clone(),
             reconnect_registry: self.reconnect_registry.clone(),
+            keepalive: self.keepalive.clone(),
+            force_reconnect: self.force_reconnect.clone(),
+            closed: self.closed.clone(),
             executor: self.executor.clone(),
             timer: self.timer.clone(),
             timeout: self.timeout,
@@ -73,15 +190,7 @@ impl<E: ProtocolError> Client<E> {
         executor: Box<dyn Executor>,
         timer: Box<dyn Timer>,
     ) -> Self {
-        Self::from_transport_with_reconnect(
-            sink,
-            stream,
-            timeout,
-            executor,
-            timer,
-            None,
-            ReconnectPolicy::default(),
-        )
+        Self::from_transport_with_config(sink, stream, executor, timer, ClientConfig::new(timeout))
     }
 
     /// Same as [`Client::from_transport`], but with automatic reconnect: when the transport
@@ -93,20 +202,60 @@ impl<E: ProtocolError> Client<E> {
     /// this constructor with a WebSocket-backed `Reconnector`.
     pub fn from_transport_with_reconnect(
         sink: Box<dyn TransportSink>,
-        mut stream: Box<dyn TransportStream>,
+        stream: Box<dyn TransportStream>,
         timeout: Duration,
         executor: Box<dyn Executor>,
         timer: Box<dyn Timer>,
         reconnector: Option<Box<dyn Reconnector>>,
         reconnect_policy: ReconnectPolicy,
     ) -> Self {
+        let mut config = ClientConfig::new(timeout);
+        config.reconnector = reconnector;
+        config.reconnect_policy = reconnect_policy;
+        Self::from_transport_with_config(sink, stream, executor, timer, config)
+    }
+
+    /// The constructor the other two delegate to: everything optional lives in [`ClientConfig`]
+    /// instead of a growing positional parameter list.
+    ///
+    /// Spawns two background tasks on `executor`: the read loop, and a keepalive task. The
+    /// keepalive task is spawned even when `config.keepalive` is `Disabled`, where it simply
+    /// parks until someone calls [`Client::set_ping_interval`] - otherwise a client built with
+    /// keepalive off could never have it turned on later, which is exactly what a CSMS writing
+    /// `WebSocketPingInterval` needs to do.
+    pub fn from_transport_with_config(
+        sink: Box<dyn TransportSink>,
+        mut stream: Box<dyn TransportStream>,
+        executor: Box<dyn Executor>,
+        timer: Box<dyn Timer>,
+        config: ClientConfig,
+    ) -> Self {
+        let ClientConfig {
+            timeout,
+            reconnector,
+            reconnect_policy,
+            keepalive,
+        } = config;
+
         let sink = Arc::new(SharedMutex::new(sink));
         let pending_responses: PendingResponses<E> = Arc::new(SharedMutex::new(BTreeMap::new()));
         let request_senders: RequestSenders = Arc::new(SharedMutex::new(BTreeMap::new()));
         let notification_senders: NotificationSenders = Arc::new(SharedMutex::new(BTreeMap::new()));
-        let pong_waiters: PongWaiters = Arc::new(SharedMutex::new(VecDeque::new()));
+        let pong_waiters: PongWaiters = Arc::new(SharedMutex::new(PongState::default()));
         let ping_registry = Arc::new(BroadcastRegistry::new());
         let reconnect_registry = Arc::new(BroadcastRegistry::new());
+        let keepalive_state = Arc::new(KeepaliveState {
+            interval_millis: AtomicU32::new(
+                keepalive
+                    .initial_interval()
+                    .map(|d| d.as_millis().min(u32::MAX as u128) as u32)
+                    .unwrap_or(0),
+            ),
+            changed: Notify::new(),
+            policy: keepalive.policy(),
+        });
+        let force_reconnect = Notify::new();
+        let closed = Arc::new(AtomicBool::new(false));
         let executor: Arc<dyn Executor> = Arc::from(executor);
         let timer: Arc<dyn Timer> = Arc::from(timer);
 
@@ -118,12 +267,62 @@ impl<E: ProtocolError> Client<E> {
         let read_reconnect_registry = reconnect_registry.clone();
         let read_sink = sink.clone();
         let read_timer = timer.clone();
+        let read_force_reconnect = force_reconnect.clone();
+        let read_closed = closed.clone();
+
+        // Honoring a forced reconnect means abandoning the current transport. With no
+        // reconnector there is nothing to abandon it *for*, and breaking the read loop would
+        // leave a permanently deaf client - strictly worse than an unanswered ping. So keepalive
+        // can only ever escalate to a redial when redialling is actually configured. An explicit
+        // `disconnect()` is different: it wants the loop gone, reconnector or not.
+        let honor_force_reconnect = reconnector.is_some();
 
         executor.spawn(Box::pin(async move {
-            loop {
+            // Persists across connections on purpose. Resetting it per connection is what made a
+            // peer that accepts-then-immediately-closes a zero-delay hot loop: every dial
+            // "succeeded", so the backoff never advanced past its first step. It is reset by
+            // evidence that a connection actually works (see the inbound-event arm below), not by
+            // the mere fact that a dial completed.
+            let mut attempt = 0u32;
+
+            'connection: loop {
+                let mut reason = LoopExit::Eof;
                 loop {
-                    match stream.recv().await {
-                        Ok(Some(TransportEvent::Frame(frame))) => {
+                    // `recv` is always raced against the wake signal, even with no reconnector,
+                    // so `disconnect()` can pull the loop out of a `recv` that would otherwise
+                    // park until the OS TCP timeout. This is why the cancel-safety contract on
+                    // `TransportStream::recv` is unconditional.
+                    let event = match with_cancel(stream.recv(), read_force_reconnect.wait()).await
+                    {
+                        Ok(event) => event,
+                        Err(_) => {
+                            // Woken on purpose. An explicit shutdown outranks everything.
+                            if read_closed.load(Ordering::SeqCst) {
+                                reason = LoopExit::Shutdown;
+                                break;
+                            }
+                            if honor_force_reconnect {
+                                reason = LoopExit::Forced;
+                                break;
+                            }
+                            // Nothing to redial with, so keep reading rather than going deaf.
+                            continue;
+                        }
+                    };
+
+                    let event = match event {
+                        Ok(Some(event)) => event,
+                        Ok(None) | Err(_) => break,
+                    };
+
+                    // Anything arriving proves this connection is real and not an
+                    // accept-then-close, so stop escalating the backoff. Dialling successfully is
+                    // deliberately *not* treated as proof - that is exactly what the hot-loop bug
+                    // mistook for a healthy connection.
+                    attempt = 0;
+
+                    match event {
+                        TransportEvent::Frame(frame) => {
                             handle_frame::<E>(
                                 &frame,
                                 &read_pending_responses,
@@ -133,27 +332,84 @@ impl<E: ProtocolError> Client<E> {
                             )
                             .await;
                         }
-                        Ok(Some(TransportEvent::Ping)) => {
+                        TransportEvent::Ping(payload) => {
                             read_ping_registry.notify_all().await;
                             let mut lock = read_sink.lock().await;
-                            let _ = lock.pong().await;
+                            // RFC 6455: a pong must echo the triggering ping's payload.
+                            let _ = lock.pong(payload).await;
                         }
-                        Ok(Some(TransportEvent::Pong)) => {
+                        TransportEvent::Pong(payload) => {
+                            let token = <[u8; 8]>::try_from(payload.as_slice())
+                                .map(u64::from_be_bytes)
+                                .ok();
                             let mut lock = read_pong_waiters.lock().await;
-                            if let Some(waiter) = lock.pop_front() {
-                                waiter.send(());
+                            match token.and_then(|token| lock.waiters.remove(&token)) {
+                                Some(waiter) => waiter.send(()),
+                                // Either an unsolicited pong, or one whose ping already timed
+                                // out. Both are dropped rather than resolving some other
+                                // outstanding ping, which is what the old positional matching
+                                // did wrong.
+                                None => tracing::debug!(
+                                    "ocpp-client: pong matched no outstanding ping"
+                                ),
                             }
                         }
-                        Ok(None) | Err(_) => break,
                     }
                 }
 
+                // The EOF path lands here too, and `disconnect()` produces one: it closes the
+                // sink, which on a real transport ends the stream. Without this check that EOF
+                // is indistinguishable from a dropped connection, and the reconnector undoes the
+                // shutdown the caller just asked for.
+                if matches!(reason, LoopExit::Shutdown) || read_closed.load(Ordering::SeqCst) {
+                    tracing::info!("ocpp-client: read loop stopped after an explicit disconnect");
+                    read_pong_waiters.lock().await.waiters.clear();
+                    break 'connection;
+                }
+
                 let Some(reconnector) = reconnector.as_ref() else {
-                    break;
+                    break 'connection;
                 };
 
-                let mut attempt = 0u32;
+                if matches!(reason, LoopExit::Forced) {
+                    // Courtesy close so a peer that *is* still listening sees a clean shutdown
+                    // rather than a vanished socket. Bounded, because the whole reason we got
+                    // here is that this socket may be dead - an unbounded close could park the
+                    // read loop for as long as the OS TCP timeout, which is precisely what
+                    // forcing a reconnect was meant to avoid.
+                    let mut lock = read_sink.lock().await;
+                    let _ = with_timeout(read_timer.as_ref(), timeout, lock.close()).await;
+                }
+
+                // Outstanding pings belong to the connection that just died; a pong can never
+                // arrive for them now. Leaving them would also mean the keepalive task's first
+                // ping on the new connection competes with corpses from the old one.
+                read_pong_waiters.lock().await.waiters.clear();
+
                 loop {
+                    // Wait *before* dialling, not only after a failed dial. The old order meant a
+                    // dial that succeeded and then instantly dropped never waited at all.
+                    let delay = reconnect_policy.jittered_delay_for(attempt);
+                    attempt = attempt.saturating_add(1);
+
+                    // Interruptible, so `disconnect()` during a long backoff takes effect now
+                    // rather than after up to `max_delay`. A wake that isn't a shutdown (keepalive
+                    // giving up on the connection we are already replacing) just shortens this
+                    // one wait - it can't recur faster than the keepalive interval, so it can't
+                    // reopen the hot loop.
+                    if with_cancel(read_timer.delay(delay), read_force_reconnect.wait())
+                        .await
+                        .is_err()
+                        && read_closed.load(Ordering::SeqCst)
+                    {
+                        tracing::info!("ocpp-client: reconnect abandoned after a disconnect");
+                        break 'connection;
+                    }
+
+                    if read_closed.load(Ordering::SeqCst) {
+                        break 'connection;
+                    }
+
                     match reconnector.connect().await {
                         Ok((new_sink, new_stream)) => {
                             *read_sink.lock().await = new_sink;
@@ -164,15 +420,13 @@ impl<E: ProtocolError> Client<E> {
                         }
                         Err(err) => {
                             tracing::warn!(attempt, error = %err, "ocpp-client: reconnect attempt failed");
-                            read_timer.delay(reconnect_policy.delay_for(attempt)).await;
-                            attempt = attempt.saturating_add(1);
                         }
                     }
                 }
             }
         }));
 
-        Self {
+        let client = Self {
             sink,
             pending_responses,
             request_senders,
@@ -180,10 +434,20 @@ impl<E: ProtocolError> Client<E> {
             pong_waiters,
             ping_registry,
             reconnect_registry,
-            executor,
+            keepalive: keepalive_state,
+            force_reconnect,
+            closed,
+            executor: executor.clone(),
             timer,
             timeout,
-        }
+        };
+
+        let keepalive_client = client.clone();
+        executor.spawn(Box::pin(
+            async move { keepalive_loop(keepalive_client).await },
+        ));
+
+        client
     }
 
     /// Send a CALL for `A` and wait for the matching CALLRESULT/CALLERROR.
@@ -206,13 +470,17 @@ impl<E: ProtocolError> Client<E> {
         let chan: Chan<(String, Value)> = Chan::new();
         {
             let mut lock = self.request_senders.lock().await;
-            lock.insert(A::NAME.to_string(), chan.clone());
+            // Retire the handler being replaced. Overwriting the map entry alone only made the
+            // old task unreachable, not finished - it stayed parked on a channel nothing could
+            // ever deliver to, leaking one task per re-registration.
+            if let Some(previous) = lock.insert(A::NAME.to_string(), chan.clone()) {
+                previous.close();
+            }
         }
 
         let client = self.clone();
         self.executor.spawn(Box::pin(async move {
-            loop {
-                let (message_id, payload) = chan.recv().await;
+            while let Some((message_id, payload)) = chan.recv().await {
                 match serde_json::from_value::<A::Request>(payload) {
                     Ok(request) => {
                         let response = callback(request, client.clone()).await;
@@ -232,6 +500,14 @@ impl<E: ProtocolError> Client<E> {
 
     /// Wait for exactly one CALL for action `A` (bounded by the client's timeout), answer
     /// it with `callback`, and return the parsed request. Only useful in tests.
+    ///
+    /// The registration is removed again on the way out, whichever way that is. Leaving it in
+    /// place left the action bound to a channel with no reader, so any *later* CALL for it was
+    /// queued and silently forgotten - the peer got no CALLRESULT and no CALLERROR either, which
+    /// looks exactly like the client having hung.
+    ///
+    /// Note this does not restore a handler that [`Client::on`] had registered for the same
+    /// action beforehand; registering replaces, as `on`'s own docs say.
     #[cfg(feature = "test")]
     pub async fn wait_for<A, F, FF>(&self, mut callback: F) -> Result<A::Request, ClientError<E>>
     where
@@ -242,19 +518,41 @@ impl<E: ProtocolError> Client<E> {
         let chan: Chan<(String, Value)> = Chan::new();
         {
             let mut lock = self.request_senders.lock().await;
-            lock.insert(A::NAME.to_string(), chan.clone());
+            if let Some(previous) = lock.insert(A::NAME.to_string(), chan.clone()) {
+                previous.close();
+            }
         }
 
-        match with_timeout(self.timer.as_ref(), self.timeout, chan.recv()).await {
-            Ok((message_id, payload)) => {
-                let for_callback: A::Request =
-                    serde_json::from_value(payload.clone()).map_err(ClientError::Decode)?;
-                let response = callback(for_callback, self.clone()).await;
-                self.do_send_response(response, &message_id).await;
-                serde_json::from_value(payload).map_err(ClientError::Decode)
+        let outcome = match with_timeout(self.timer.as_ref(), self.timeout, chan.recv()).await {
+            Ok(Some((message_id, payload))) => {
+                match serde_json::from_value::<A::Request>(payload.clone()) {
+                    Ok(for_callback) => {
+                        let response = callback(for_callback, self.clone()).await;
+                        self.do_send_response(response, &message_id).await;
+                        serde_json::from_value(payload).map_err(ClientError::Decode)
+                    }
+                    Err(err) => Err(ClientError::Decode(err)),
+                }
             }
+            // The channel was closed out from under us - another registration for the same
+            // action superseded this one.
+            Ok(None) => Err(ClientError::Closed),
             Err(_) => Err(ClientError::Timeout),
+        };
+
+        {
+            let mut lock = self.request_senders.lock().await;
+            // Only remove our own registration: something else may have replaced it while we
+            // were waiting, and tearing that out would break whoever installed it.
+            if lock
+                .get(A::NAME)
+                .is_some_and(|current| current.is_same(&chan))
+            {
+                lock.remove(A::NAME);
+            }
         }
+
+        outcome
     }
 
     /// Send a `SEND` (OCPP-J 2.1 only) fire-and-forget message: writes the frame and returns as
@@ -264,6 +562,9 @@ impl<E: ProtocolError> Client<E> {
         &self,
         payload: A::Payload,
     ) -> Result<(), ClientError<E>> {
+        if self.is_closed() {
+            return Err(ClientError::Closed);
+        }
         let message_id = Uuid::new_v4();
         let payload = serde_json::to_value(&payload).map_err(ClientError::Decode)?;
         let send = RawSend(
@@ -291,13 +592,14 @@ impl<E: ProtocolError> Client<E> {
         let chan: Chan<Value> = Chan::new();
         {
             let mut lock = self.notification_senders.lock().await;
-            lock.insert(A::NAME.to_string(), chan.clone());
+            if let Some(previous) = lock.insert(A::NAME.to_string(), chan.clone()) {
+                previous.close();
+            }
         }
 
         let client = self.clone();
         self.executor.spawn(Box::pin(async move {
-            loop {
-                let payload = chan.recv().await;
+            while let Some(payload) = chan.recv().await {
                 match serde_json::from_value::<A::Payload>(payload) {
                     Ok(payload) => callback(payload, client.clone()).await,
                     Err(err) => {
@@ -308,20 +610,118 @@ impl<E: ProtocolError> Client<E> {
         }));
     }
 
+    /// Send one ping and wait for the matching pong, bounded by the client's timeout.
+    ///
+    /// The pong is matched by correlation token, not arrival order: the ping carries an
+    /// 8-byte token as its payload and only a pong echoing that exact payload resolves this
+    /// call. RFC 6455 requires peers to echo ping payloads, so this is exact against any
+    /// compliant server; a pong that echoes something else is ignored, and this call times out.
+    ///
+    /// This is the manual, one-shot ping. For scheduled keepalive - including detecting a peer
+    /// that has stopped answering and forcing a redial - see [`Client::set_ping_interval`] and
+    /// `KeepaliveBehavior`.
     pub async fn send_ping(&self) -> Result<(), ClientError<E>> {
+        self.send_ping_with_timeout(self.timeout).await
+    }
+
+    /// [`Client::send_ping`] with an explicit pong deadline, so keepalive can use
+    /// `KeepalivePolicy::timeout` instead of the client's request timeout.
+    async fn send_ping_with_timeout(&self, timeout: Duration) -> Result<(), ClientError<E>> {
+        if self.is_closed() {
+            return Err(ClientError::Closed);
+        }
         let waiter = OneShot::new();
-        {
+        let token = {
             let mut lock = self.pong_waiters.lock().await;
-            lock.push_back(waiter.clone());
-        }
-        {
+            let token = lock.next_token;
+            lock.next_token = lock.next_token.wrapping_add(1);
+            lock.waiters.insert(token, waiter.clone());
+            token
+        };
+
+        let sent = {
             let mut lock = self.sink.lock().await;
-            lock.ping().await.map_err(ClientError::Transport)?;
+            lock.ping(Vec::from(token.to_be_bytes())).await
+        };
+        if let Err(err) = sent {
+            self.forget_ping(token).await;
+            return Err(ClientError::Transport(err));
         }
-        with_timeout(self.timer.as_ref(), self.timeout, waiter.wait())
-            .await
-            .map(|_| ())
-            .map_err(|_| ClientError::Timeout)
+
+        match with_timeout(self.timer.as_ref(), timeout, waiter.wait()).await {
+            Ok(()) => Ok(()),
+            Err(_) => {
+                // Drop our own waiter. Skipping this is what used to poison the client: an
+                // abandoned waiter sat in the table forever, and (under the old positional
+                // matching) stole the next ping's pong.
+                self.forget_ping(token).await;
+                Err(ClientError::Timeout)
+            }
+        }
+    }
+
+    async fn forget_ping(&self, token: u64) {
+        self.pong_waiters.lock().await.waiters.remove(&token);
+    }
+
+    /// How many requests are still waiting for a CALLRESULT/CALLERROR.
+    ///
+    /// Test-only instrumentation: this table is bookkeeping that should return to zero once every
+    /// request has either been answered or given up, and a leak in it is otherwise invisible from
+    /// outside - it shows up only as memory growth on a charge point that has been running for
+    /// weeks. `tests/ocpp_1_6_bookkeeping.rs` asserts on it.
+    #[cfg(feature = "test")]
+    pub async fn pending_request_count(&self) -> usize {
+        self.pending_responses.lock().await.len()
+    }
+
+    /// How many pings are still waiting for a pong. Test-only, same rationale as
+    /// [`Client::pending_request_count`].
+    #[cfg(feature = "test")]
+    pub async fn pending_ping_count(&self) -> usize {
+        self.pong_waiters.lock().await.waiters.len()
+    }
+
+    /// The keepalive ping interval currently in force, or `None` when keepalive is off.
+    ///
+    /// This is the value to report for `OCPPCommCtrlr.WebSocketPingInterval` (2.0.1/2.1) or the
+    /// `WebSocketPingInterval` configuration key (1.6) - `None` maps to the spec's `0`. Cheap
+    /// and non-blocking, so a `GetVariables`/`GetConfiguration` handler can call it directly.
+    pub fn ping_interval(&self) -> Option<Duration> {
+        self.keepalive.interval()
+    }
+
+    /// Change the keepalive ping interval on a live connection, for a CSMS writing
+    /// `WebSocketPingInterval` via `SetVariables`/`ChangeConfiguration`.
+    ///
+    /// `None` - or `Some(Duration::ZERO)`, matching the spec's `0` - disables pinging. Takes
+    /// effect immediately: the keepalive task is woken rather than finishing the interval it was
+    /// already waiting out, so shortening a 1-hour interval doesn't take up to an hour to apply.
+    /// Enabling works even on a client built with `KeepaliveBehavior::Disabled`.
+    pub fn set_ping_interval(&self, interval: Option<Duration>) {
+        let interval = interval.filter(|d| !d.is_zero());
+        self.keepalive.set_interval(interval);
+        tracing::info!(
+            interval_millis = interval.map(|d| d.as_millis() as u64).unwrap_or(0),
+            "ocpp-client: keepalive ping interval updated"
+        );
+    }
+
+    /// Abandon the current transport and redial, without waiting for it to notice it is dead.
+    ///
+    /// This is what keepalive escalates to after `KeepalivePolicy::max_missed` unanswered pings,
+    /// exposed because a caller with its own liveness signal (an application-level heartbeat
+    /// going unanswered, say) has the same problem. A half-open TCP connection can otherwise
+    /// keep the read loop parked until the OS timeout, which no amount of protocol-level
+    /// bookkeeping can shorten.
+    ///
+    /// No-op when the client was built without a reconnector: there would be nothing to redial
+    /// with, and dropping the current connection anyway would just make the client deaf.
+    pub fn force_reconnect(&self) {
+        if self.is_closed() {
+            return;
+        }
+        self.force_reconnect.notify();
     }
 
     pub async fn on_ping<
@@ -366,9 +766,47 @@ impl<E: ProtocolError> Client<E> {
         }));
     }
 
+    /// Shut this client down for good: close the transport, stop the read loop, stop keepalive,
+    /// and do **not** redial.
+    ///
+    /// The shutdown is sticky and takes precedence over every automatic recovery path. That
+    /// matters because closing the transport looks exactly like a dropped connection from the read
+    /// loop's side - it previously produced an EOF the reconnector dutifully redialled, so on the
+    /// default [`crate::ConnectOptions`] (reconnect enabled) there was no way to stop a client at
+    /// all. After this returns:
+    ///
+    /// - the read loop has been told to exit rather than redial, whether it was parked in `recv`
+    ///   or sees the EOF from the close;
+    /// - the keepalive task stops pinging, and [`Client::set_ping_interval`] cannot restart it;
+    /// - [`Client::force_reconnect`] is a no-op;
+    /// - further `call`/`send_*`/`send_ping` return [`ClientError::Closed`] instead of writing to
+    ///   a dead transport and waiting out the timeout.
+    ///
+    /// Idempotent: calling it again is a no-op returning `Ok(())`. Reconnecting afterwards means
+    /// building a new `Client`.
+    ///
+    /// This only covers *deliberate* shutdown. An unrequested drop is still redialled as before.
     pub async fn disconnect(&self) -> Result<(), ClientError<E>> {
+        if self.closed.swap(true, Ordering::SeqCst) {
+            return Ok(());
+        }
+
+        // Both loops re-read `closed` as soon as they wake, so the flag has to be set first.
+        self.force_reconnect.notify();
+        self.keepalive.changed.notify();
+
         let mut lock = self.sink.lock().await;
         lock.close().await.map_err(ClientError::Transport)
+    }
+
+    /// Whether [`Client::disconnect`] has been called.
+    ///
+    /// This reflects deliberate shutdown only - it stays `false` while a connection is dropped and
+    /// being redialled, because such a client is still live and will resume on its own. There is
+    /// deliberately no "is the socket up right now" accessor: it would be stale the moment it
+    /// returned, and [`Client::on_reconnect`] is the reliable way to observe reconnection.
+    pub fn is_closed(&self) -> bool {
+        self.closed.load(Ordering::SeqCst)
     }
 
     async fn do_send_request<P: Serialize, R: DeserializeOwned>(
@@ -376,6 +814,11 @@ impl<E: ProtocolError> Client<E> {
         request: P,
         action: &str,
     ) -> Result<R, ClientError<E>> {
+        // Fail fast rather than writing to a closed transport and then waiting out the full
+        // request timeout for a response that cannot arrive.
+        if self.is_closed() {
+            return Err(ClientError::Closed);
+        }
         let message_id = Uuid::new_v4();
         let payload = serde_json::to_value(&request).map_err(ClientError::Decode)?;
         let call = RawCall(
@@ -392,19 +835,36 @@ impl<E: ProtocolError> Client<E> {
             lock.insert(message_id, waiter.clone());
         }
 
-        {
+        let sent = {
             let mut lock = self.sink.lock().await;
-            lock.send(frame).await.map_err(ClientError::Transport)?;
+            lock.send(frame).await
+        };
+        if let Err(err) = sent {
+            // Never reached the wire, so no response can ever arrive to clear this entry.
+            self.forget_pending(message_id).await;
+            return Err(ClientError::Transport(err));
         }
 
-        let result = with_timeout(self.timer.as_ref(), self.timeout, waiter.wait())
-            .await
-            .map_err(|_| ClientError::Timeout)?;
+        let result = match with_timeout(self.timer.as_ref(), self.timeout, waiter.wait()).await {
+            Ok(result) => result,
+            Err(_) => {
+                // Drop our own waiter. `handle_frame` only removes entries when a response
+                // actually arrives, so without this every timed-out request left one behind
+                // permanently - unbounded growth on a charge point that has been up for weeks
+                // with an intermittent CSMS. Same failure the pong table used to have.
+                self.forget_pending(message_id).await;
+                return Err(ClientError::Timeout);
+            }
+        };
 
         match result {
             Ok(value) => serde_json::from_value(value).map_err(ClientError::Decode),
             Err(e) => Err(ClientError::Protocol(e)),
         }
+    }
+
+    async fn forget_pending(&self, message_id: Uuid) {
+        self.pending_responses.lock().await.remove(&message_id);
     }
 
     async fn do_send_response<R: Serialize>(&self, response: Result<R, E>, message_id: &str) {
@@ -435,6 +895,76 @@ impl<E: ProtocolError> Client<E> {
             }
             Err(err) => {
                 tracing::error!(error = %err, "ocpp-client: failed to encode response");
+            }
+        }
+    }
+}
+
+/// The scheduled-ping task spawned by [`Client::from_transport_with_config`].
+///
+/// Runs for the client's whole life, including across reconnects - `send_ping` writes through
+/// `Client`'s shared sink handle, which the read loop swaps in place on redial, so nothing here
+/// has to know a reconnect happened.
+///
+/// Sleeping is `with_timeout(timer, interval, changed.wait())` rather than a plain delay: it is
+/// already exactly "wait out the interval, but wake early if reconfigured", so `set_ping_interval`
+/// applies immediately without a second timer or a polling granularity.
+async fn keepalive_loop<E: ProtocolError>(client: Client<E>) {
+    let state = client.keepalive.clone();
+    let policy = state.policy;
+    let misses_allowed = policy.misses_allowed();
+    let ping_timeout = policy.timeout.unwrap_or(client.timeout);
+    let mut missed = 0u32;
+
+    loop {
+        // `disconnect()` sets this and then notifies `changed`, so both waits below wake up here.
+        if client.is_closed() {
+            return;
+        }
+
+        let Some(interval) = state.interval() else {
+            // Keepalive off: park until someone turns it on (or the client shuts down).
+            state.changed.wait().await;
+            missed = 0;
+            continue;
+        };
+
+        if with_timeout(client.timer.as_ref(), interval, state.changed.wait())
+            .await
+            .is_ok()
+        {
+            // Reconfigured mid-wait; re-read the interval rather than pinging on the old one.
+            missed = 0;
+            continue;
+        }
+
+        // The interval could have been zeroed - or the client shut down - between the wait
+        // ending and here.
+        if client.is_closed() {
+            return;
+        }
+        if state.interval().is_none() {
+            continue;
+        }
+
+        match client.send_ping_with_timeout(ping_timeout).await {
+            Ok(()) => missed = 0,
+            Err(err) => {
+                missed = missed.saturating_add(1);
+                tracing::warn!(
+                    missed,
+                    misses_allowed,
+                    error = %err,
+                    "ocpp-client: keepalive ping went unanswered"
+                );
+                if missed >= misses_allowed {
+                    missed = 0;
+                    tracing::error!(
+                        misses_allowed,
+                        "ocpp-client: peer stopped answering pings, forcing a redial"
+                    );
+                    client.force_reconnect();
+                }
             }
         }
     }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1,4 +1,6 @@
-use crate::reconnect::{ReconnectBehavior, ReconnectPolicy, Reconnector};
+use crate::client::ClientConfig;
+use crate::keepalive::KeepaliveBehavior;
+use crate::reconnect::{ReconnectBehavior, Reconnector};
 use crate::transport::{TransportError, TransportSink, TransportStream};
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
@@ -15,7 +17,7 @@ use url::Url;
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct ConnectOptions<'a> {
     pub username: Option<&'a str>,
     pub password: Option<&'a str>,
@@ -52,6 +54,38 @@ pub struct ConnectOptions<'a> {
     /// `ReconnectBehavior::Disabled` still wins - it is an explicit "do not redial", and
     /// supplying a reconnector does not quietly turn reconnect back on.
     pub reconnector: Option<Arc<dyn Reconnector>>,
+    /// Whether the client pings the CSMS on a schedule, and when it gives up on an unresponsive
+    /// one and redials. Defaults to `KeepaliveBehavior::Enabled` with
+    /// `KeepalivePolicy::default()` - a 60-second interval, tolerating one missed pong.
+    ///
+    /// Keepalive is on by default here for the same reason `reconnect` is: without it, a
+    /// half-open connection (a NAT table entry dropped, a mobile link that went away without a
+    /// FIN) is invisible, and the reconnect machinery never gets a chance to fire because the
+    /// read loop is parked in `recv` until the OS TCP timeout. Set `KeepaliveBehavior::Disabled`
+    /// if the CSMS pings the charge point instead, or if the deployment forbids unsolicited
+    /// traffic.
+    ///
+    /// The interval is also readable and writable at runtime via `Client::ping_interval`/
+    /// `Client::set_ping_interval`, which is how `WebSocketPingInterval` gets reported to, and
+    /// updated by, a CSMS.
+    pub keepalive: KeepaliveBehavior,
+}
+
+/// Hand-written rather than derived because `keepalive` defaults to *enabled*, unlike
+/// `KeepaliveBehavior`'s own `Default` - see the field's docs for why the WebSocket convenience
+/// path opts in where the bare `Client` constructors don't.
+impl Default for ConnectOptions<'_> {
+    fn default() -> Self {
+        Self {
+            username: None,
+            password: None,
+            timeout: None,
+            reconnect: ReconnectBehavior::default(),
+            tls_config: None,
+            reconnector: None,
+            keepalive: KeepaliveBehavior::Enabled(crate::keepalive::KeepalivePolicy::default()),
+        }
+    }
 }
 
 impl core::fmt::Debug for ConnectOptions<'_> {
@@ -71,6 +105,7 @@ impl core::fmt::Debug for ConnectOptions<'_> {
                 "reconnector",
                 &self.reconnector.as_ref().map(|_| "<custom>"),
             )
+            .field("keepalive", &self.keepalive)
             .finish()
     }
 }
@@ -191,39 +226,33 @@ pub async fn connect(
         .find(|v| v.protocol() == negotiated)
         .map(|v| v.protocol())
         .ok_or_else(|| format!("Server negotiated unsupported protocol: {negotiated}"))?;
-    let (timeout, reconnector, policy) = prepare(address, protocol, options);
+    let config = prepare(address, protocol, options);
     let (sink, source) = crate::transport::websocket::split(stream);
 
     Ok(match protocol {
         #[cfg(feature = "ocpp_1_6")]
-        "ocpp1.6" => NegotiatedClient::V1_6(crate::Client::from_transport_with_reconnect(
+        "ocpp1.6" => NegotiatedClient::V1_6(crate::Client::from_transport_with_config(
             sink,
             source,
-            timeout,
             Box::new(crate::runtime::tokio::TokioExecutor),
             Box::new(crate::runtime::tokio::TokioTimer),
-            reconnector,
-            policy,
+            config,
         )),
         #[cfg(feature = "ocpp_2_0_1")]
-        "ocpp2.0.1" => NegotiatedClient::V2_0_1(crate::Client::from_transport_with_reconnect(
+        "ocpp2.0.1" => NegotiatedClient::V2_0_1(crate::Client::from_transport_with_config(
             sink,
             source,
-            timeout,
             Box::new(crate::runtime::tokio::TokioExecutor),
             Box::new(crate::runtime::tokio::TokioTimer),
-            reconnector,
-            policy,
+            config,
         )),
         #[cfg(feature = "ocpp_2_1")]
-        "ocpp2.1" => NegotiatedClient::V2_1(crate::Client::from_transport_with_reconnect(
+        "ocpp2.1" => NegotiatedClient::V2_1(crate::Client::from_transport_with_config(
             sink,
             source,
-            timeout,
             Box::new(crate::runtime::tokio::TokioExecutor),
             Box::new(crate::runtime::tokio::TokioTimer),
-            reconnector,
-            policy,
+            config,
         )),
         _ => unreachable!("protocol only ever holds a value returned by OcppVersion::protocol"),
     })
@@ -235,17 +264,15 @@ pub async fn connect_1_6(
     address: &str,
     options: Option<ConnectOptions<'_>>,
 ) -> Result<crate::ocpp_1_6::OCPP1_6Client, Box<dyn std::error::Error + Send + Sync>> {
-    let (timeout, reconnector, policy) = prepare(address, "ocpp1.6", options.clone());
+    let config = prepare(address, "ocpp1.6", options.clone());
     let (stream, _protocol) = setup_socket(address, "ocpp1.6", options).await?;
     let (sink, source) = crate::transport::websocket::split(stream);
-    Ok(crate::Client::from_transport_with_reconnect(
+    Ok(crate::Client::from_transport_with_config(
         sink,
         source,
-        timeout,
         Box::new(crate::runtime::tokio::TokioExecutor),
         Box::new(crate::runtime::tokio::TokioTimer),
-        reconnector,
-        policy,
+        config,
     ))
 }
 
@@ -255,17 +282,15 @@ pub async fn connect_2_0_1(
     address: &str,
     options: Option<ConnectOptions<'_>>,
 ) -> Result<crate::ocpp_2_0_1::OCPP2_0_1Client, Box<dyn std::error::Error + Send + Sync>> {
-    let (timeout, reconnector, policy) = prepare(address, "ocpp2.0.1", options.clone());
+    let config = prepare(address, "ocpp2.0.1", options.clone());
     let (stream, _protocol) = setup_socket(address, "ocpp2.0.1", options).await?;
     let (sink, source) = crate::transport::websocket::split(stream);
-    Ok(crate::Client::from_transport_with_reconnect(
+    Ok(crate::Client::from_transport_with_config(
         sink,
         source,
-        timeout,
         Box::new(crate::runtime::tokio::TokioExecutor),
         Box::new(crate::runtime::tokio::TokioTimer),
-        reconnector,
-        policy,
+        config,
     ))
 }
 
@@ -275,32 +300,39 @@ pub async fn connect_2_1(
     address: &str,
     options: Option<ConnectOptions<'_>>,
 ) -> Result<crate::ocpp_2_1::OCPP2_1Client, Box<dyn std::error::Error + Send + Sync>> {
-    let (timeout, reconnector, policy) = prepare(address, "ocpp2.1", options.clone());
+    let config = prepare(address, "ocpp2.1", options.clone());
     let (stream, _protocol) = setup_socket(address, "ocpp2.1", options).await?;
     let (sink, source) = crate::transport::websocket::split(stream);
-    Ok(crate::Client::from_transport_with_reconnect(
+    Ok(crate::Client::from_transport_with_config(
         sink,
         source,
-        timeout,
         Box::new(crate::runtime::tokio::TokioExecutor),
         Box::new(crate::runtime::tokio::TokioTimer),
-        reconnector,
-        policy,
+        config,
     ))
 }
 
-/// Pulls the timeout/reconnect settings out of `options` and, if reconnect is enabled, builds
-/// the `Reconnector` that redials this same address/protocol/credentials. Shared by all three
-/// `connect_*` entry points.
+/// Turns `options` into the [`ClientConfig`] the `Client` constructor takes and, if reconnect is
+/// enabled, builds the `Reconnector` that redials this same address/protocol/credentials. Shared
+/// by all three `connect_*` entry points and by `connect`.
+///
+/// Note the two different defaults for an absent `options`: `ConnectOptions::default()` is used
+/// for `reconnect`/`keepalive` (both enabled), so passing `None` behaves the same as passing
+/// `Some(Default::default())` rather than silently disabling them.
 fn prepare(
     address: &str,
     protocol: &'static str,
     options: Option<ConnectOptions<'_>>,
-) -> (Duration, Option<Box<dyn Reconnector>>, ReconnectPolicy) {
+) -> ClientConfig {
+    let defaults = ConnectOptions::default();
     let timeout = options
         .as_ref()
         .and_then(|o| o.timeout)
         .unwrap_or(DEFAULT_TIMEOUT);
+    let keepalive = options
+        .as_ref()
+        .map(|o| o.keepalive)
+        .unwrap_or(defaults.keepalive);
     let reconnect = options.as_ref().map(|o| o.reconnect).unwrap_or_default();
     let username = options
         .as_ref()
@@ -314,22 +346,24 @@ fn prepare(
 
     let custom = options.as_ref().and_then(|o| o.reconnector.clone());
 
+    let config = ClientConfig::new(timeout).with_keepalive(keepalive);
+
     match reconnect {
-        ReconnectBehavior::Disabled => (timeout, None, ReconnectPolicy::default()),
+        ReconnectBehavior::Disabled => config,
         ReconnectBehavior::Enabled(policy) if custom.is_some() => {
             let custom = custom.expect("guarded by the match arm");
-            (timeout, Some(Box::new(SharedReconnector(custom))), policy)
+            config.with_reconnect(Box::new(SharedReconnector(custom)), policy)
         }
-        ReconnectBehavior::Enabled(policy) => {
-            let reconnector: Box<dyn Reconnector> = Box::new(WebSocketReconnector {
+        ReconnectBehavior::Enabled(policy) => config.with_reconnect(
+            Box::new(WebSocketReconnector {
                 address: address.to_string(),
                 protocol,
                 username,
                 password,
                 tls_config,
-            });
-            (timeout, Some(reconnector), policy)
-        }
+            }),
+            policy,
+        ),
     }
 }
 
@@ -388,6 +422,10 @@ impl Reconnector for WebSocketReconnector {
                 reconnect: ReconnectBehavior::Disabled,
                 tls_config: self.tls_config.clone(),
                 reconnector: None,
+                // Both this and `reconnect` are inert here: `setup_socket` only reads the
+                // credential/TLS fields, and this path produces bare transport halves for a
+                // client whose keepalive task is already running.
+                keepalive: KeepaliveBehavior::Disabled,
             };
             let (stream, _protocol) =
                 setup_socket(&self.address, self.protocol, Some(options)).await?;

--- a/src/keepalive.rs
+++ b/src/keepalive.rs
@@ -1,0 +1,135 @@
+//! Client-initiated WebSocket keepalive: ping the peer on a fixed interval and, when it stops
+//! answering, force the connection to be redialled.
+//!
+//! This lives in the engine rather than in the WebSocket transport because
+//! `TransportSink::ping`/`TransportEvent::Pong` are already part of the transport abstraction -
+//! so `ocpp-transport-embassy-net`, or any future framed transport, gets keepalive for free
+//! without reimplementing the timing or the dead-peer logic.
+//!
+//! Shaped after `src/reconnect.rs`: a policy struct plus an `Enabled`/`Disabled` behavior enum,
+//! so `ConnectOptions` reads the same way for both.
+//!
+//! The OCPP mapping is `OCPPCommCtrlr.WebSocketPingInterval` in 2.0.1/2.1 and the
+//! `WebSocketPingInterval` configuration key in the 1.6 security whitepaper. This crate does not
+//! implement a device model; it owns the timer and exposes the value through
+//! `Client::ping_interval`/`Client::set_ping_interval` so the layer that does own the device
+//! model can report and update it.
+
+use core::time::Duration;
+
+/// How often to ping, how long to wait for each pong, and how many consecutive misses mean the
+/// connection is dead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KeepalivePolicy {
+    /// Delay between pings. `Duration::ZERO` disables pinging, matching how OCPP's
+    /// `WebSocketPingInterval` reads a 0 value.
+    pub interval: Duration,
+    /// How long to wait for each pong before counting it as missed. `None` uses the client's
+    /// own request timeout, which is what almost every caller wants - a pong that takes longer
+    /// than a CALL is already a broken link.
+    pub timeout: Option<Duration>,
+    /// Consecutive missed pongs before the connection is treated as dead and redialled. `0` is
+    /// treated as `1`. Defaults to `2` so a single dropped frame - or a peer that answers one
+    /// ping oddly - doesn't cost a reconnect.
+    pub max_missed: u32,
+}
+
+impl Default for KeepalivePolicy {
+    fn default() -> Self {
+        Self {
+            interval: Duration::from_secs(60),
+            timeout: None,
+            max_missed: 2,
+        }
+    }
+}
+
+impl KeepalivePolicy {
+    /// A policy pinging every `interval`, with default timeout and miss tolerance.
+    pub fn every(interval: Duration) -> Self {
+        Self {
+            interval,
+            ..Self::default()
+        }
+    }
+
+    /// `max_missed`, with `0` normalized to `1` - a policy that tolerated zero misses before
+    /// declaring the link dead would still have to act on the first one.
+    pub(crate) fn misses_allowed(&self) -> u32 {
+        self.max_missed.max(1)
+    }
+}
+
+/// Whether a client pings its peer on a schedule.
+///
+/// `ConnectOptions` defaults this to `Enabled(KeepalivePolicy::default())` - a charge point on a
+/// NAT'd or mobile link needs keepalive to notice a half-open connection at all, the same
+/// reasoning that makes `ReconnectBehavior` default to enabled. The lower-level
+/// `Client::from_transport*` constructors default to `Disabled`, since a caller assembling a
+/// client from raw transport halves has said nothing about wanting background traffic on it.
+///
+/// `Disabled` is not permanent: `Client::set_ping_interval` can turn pinging on later, which is
+/// what a CSMS writing `WebSocketPingInterval` via `SetVariables` needs to be able to do.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum KeepaliveBehavior {
+    Enabled(KeepalivePolicy),
+    #[default]
+    Disabled,
+}
+
+impl KeepaliveBehavior {
+    /// The starting interval, or `None` when keepalive is off. A `ZERO` interval collapses to
+    /// `None` so "disabled" has one representation inside the client.
+    pub(crate) fn initial_interval(&self) -> Option<Duration> {
+        match self {
+            KeepaliveBehavior::Enabled(policy) if !policy.interval.is_zero() => {
+                Some(policy.interval)
+            }
+            _ => None,
+        }
+    }
+
+    /// The policy to apply to pings, whether or not pinging starts out enabled - it still
+    /// governs pings that `Client::set_ping_interval` turns on later.
+    pub(crate) fn policy(&self) -> KeepalivePolicy {
+        match self {
+            KeepaliveBehavior::Enabled(policy) => *policy,
+            KeepaliveBehavior::Disabled => KeepalivePolicy::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_interval_reads_as_disabled() {
+        let behavior = KeepaliveBehavior::Enabled(KeepalivePolicy::every(Duration::ZERO));
+        assert_eq!(behavior.initial_interval(), None);
+    }
+
+    #[test]
+    fn disabled_still_carries_a_policy_for_later_enabling() {
+        assert_eq!(
+            KeepaliveBehavior::Disabled.policy(),
+            KeepalivePolicy::default()
+        );
+        assert_eq!(KeepaliveBehavior::Disabled.initial_interval(), None);
+    }
+
+    #[test]
+    fn zero_misses_allowed_normalizes_to_one() {
+        let policy = KeepalivePolicy {
+            max_missed: 0,
+            ..KeepalivePolicy::default()
+        };
+        assert_eq!(policy.misses_allowed(), 1);
+    }
+
+    #[test]
+    fn default_tolerates_one_miss_before_redialling() {
+        assert_eq!(KeepalivePolicy::default().misses_allowed(), 2);
+        assert_eq!(KeepalivePolicy::default().interval, Duration::from_secs(60));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ mod action;
 mod client;
 mod envelope;
 mod error;
+mod keepalive;
 mod reconnect;
 pub mod runtime;
 mod sync;
@@ -36,8 +37,9 @@ pub mod ocpp_2_1;
 pub use ocpp_types;
 
 pub use action::Action;
-pub use client::Client;
+pub use client::{Client, ClientConfig};
 pub use error::{ClientError, ProtocolError};
+pub use keepalive::{KeepaliveBehavior, KeepalivePolicy};
 pub use reconnect::{ReconnectBehavior, ReconnectPolicy, Reconnector};
 pub use runtime::{Elapsed, Executor, Timer};
 pub use transport::{TransportError, TransportEvent, TransportSink, TransportStream};

--- a/src/reconnect.rs
+++ b/src/reconnect.rs
@@ -31,14 +31,29 @@ pub trait Reconnector: Send + Sync + 'static {
 }
 
 /// Bounded exponential backoff between reconnect attempts. The delay doubles (by
-/// `multiplier`) after each failed attempt, capped at `max_delay` - but the number of attempts
-/// itself is unbounded: a charge point should keep trying to reach its CSMS indefinitely
-/// rather than giving up after N tries.
+/// `multiplier`) after each attempt that didn't produce a working connection, capped at
+/// `max_delay` - but the number of attempts itself is unbounded: a charge point should keep
+/// trying to reach its CSMS indefinitely rather than giving up after N tries.
+///
+/// The backoff resets as soon as a connection carries any inbound traffic, so an ordinary
+/// transient drop costs one `initial_delay` rather than an escalating one. Escalation is
+/// reserved for connections that never work - notably a peer that accepts and then immediately
+/// closes, which is indistinguishable from a successful dial until nothing arrives on it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ReconnectPolicy {
     pub initial_delay: Duration,
     pub max_delay: Duration,
     pub multiplier: u32,
+    /// Randomize each delay within `[delay / 2, delay]` ("equal jitter"). Defaults to `true`.
+    ///
+    /// Without it, every charge point that lost the same CSMS retries in lockstep, so the
+    /// endpoint coming back gets the whole fleet at once, repeatedly. Jitter spreads that out.
+    /// Half the delay is kept un-jittered so a randomly tiny value can't defeat the rate bound
+    /// the backoff exists to provide.
+    ///
+    /// Set `false` when exact retry timing matters more than fleet behavior - a deterministic
+    /// test, mostly.
+    pub jitter: bool,
 }
 
 impl Default for ReconnectPolicy {
@@ -47,13 +62,14 @@ impl Default for ReconnectPolicy {
             initial_delay: Duration::from_secs(1),
             max_delay: Duration::from_secs(60),
             multiplier: 2,
+            jitter: true,
         }
     }
 }
 
 impl ReconnectPolicy {
-    /// The delay to wait before reconnect attempt number `attempt` (0-indexed: `0` is the
-    /// delay before the first retry, right after the initial disconnect).
+    /// The un-jittered delay before reconnect attempt number `attempt` (0-indexed: `0` is the
+    /// delay before the first retry, right after the disconnect).
     pub(crate) fn delay_for(&self, attempt: u32) -> Duration {
         let mut delay = self.initial_delay;
         for _ in 0..attempt {
@@ -63,6 +79,24 @@ impl ReconnectPolicy {
             };
         }
         delay
+    }
+
+    /// [`ReconnectPolicy::delay_for`] with equal jitter applied: uniformly distributed over
+    /// `[delay / 2, delay]`, or exactly `delay` when `jitter` is off.
+    ///
+    /// Randomness comes from a throwaway v4 UUID because `uuid` is already a dependency (it
+    /// generates OCPP message ids) and its RNG already works on this crate's bare-metal target -
+    /// so this needs no additional RNG dependency and no new embedded plumbing. The arithmetic is
+    /// integer-only, avoiding a float dependency on no-FPU targets.
+    pub(crate) fn jittered_delay_for(&self, attempt: u32) -> Duration {
+        let delay = self.delay_for(attempt);
+        if !self.jitter {
+            return delay;
+        }
+        let half = delay / 2;
+        let fraction = uuid::Uuid::new_v4().as_u128() as u32;
+        let extra = (half.as_nanos() * fraction as u128) / u32::MAX as u128;
+        half + Duration::from_nanos(extra as u64)
     }
 }
 
@@ -92,6 +126,7 @@ mod tests {
             initial_delay: Duration::from_secs(1),
             max_delay: Duration::from_secs(10),
             multiplier: 2,
+            jitter: false,
         };
         assert_eq!(policy.delay_for(0), Duration::from_secs(1));
         assert_eq!(policy.delay_for(1), Duration::from_secs(2));
@@ -99,5 +134,63 @@ mod tests {
         assert_eq!(policy.delay_for(3), Duration::from_secs(8));
         assert_eq!(policy.delay_for(4), Duration::from_secs(10));
         assert_eq!(policy.delay_for(10), Duration::from_secs(10));
+    }
+
+    #[test]
+    fn jitter_off_is_exact() {
+        let policy = ReconnectPolicy {
+            initial_delay: Duration::from_secs(4),
+            jitter: false,
+            ..ReconnectPolicy::default()
+        };
+        for attempt in 0..6 {
+            assert_eq!(
+                policy.jittered_delay_for(attempt),
+                policy.delay_for(attempt)
+            );
+        }
+    }
+
+    #[test]
+    fn jitter_stays_within_half_the_delay_and_the_full_delay() {
+        let policy = ReconnectPolicy {
+            initial_delay: Duration::from_secs(8),
+            max_delay: Duration::from_secs(64),
+            multiplier: 2,
+            jitter: true,
+        };
+
+        for attempt in 0..6 {
+            let full = policy.delay_for(attempt);
+            for _ in 0..200 {
+                let jittered = policy.jittered_delay_for(attempt);
+                assert!(
+                    jittered >= full / 2 && jittered <= full,
+                    "attempt {attempt}: {jittered:?} outside [{:?}, {full:?}]",
+                    full / 2
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn jitter_actually_varies() {
+        // The floor matters more than the spread, but a constant "jitter" would defeat the
+        // point - a fleet would still retry in lockstep.
+        let policy = ReconnectPolicy::default();
+        let first = policy.jittered_delay_for(3);
+        let varies = (0..50).any(|_| policy.jittered_delay_for(3) != first);
+        assert!(varies, "jittered delays should not all be identical");
+    }
+
+    #[test]
+    fn a_zero_delay_survives_jittering() {
+        let policy = ReconnectPolicy {
+            initial_delay: Duration::ZERO,
+            max_delay: Duration::ZERO,
+            multiplier: 2,
+            jitter: true,
+        };
+        assert_eq!(policy.jittered_delay_for(0), Duration::ZERO);
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -29,9 +29,43 @@ pub trait Timer: Send + Sync + 'static {
     fn delay<'a>(&'a self, duration: Duration) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
 }
 
-/// Returned by [`with_timeout`] when `duration` elapses before `fut` resolves.
+/// Returned when a timeout elapses before the future it was racing resolves.
+///
+/// Produced by this crate's internal `with_timeout` helper; it is public because it surfaces
+/// through `Client`'s API, not because callers construct it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Elapsed;
+
+/// Returned when a cancellation signal fires before the future it was racing resolves.
+///
+/// Produced by this crate's internal `with_cancel` helper - see [`Elapsed`] for why it is public.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Cancelled;
+
+/// Race `fut` against `cancel`, resolving to whichever finishes first - the same hand-rolled
+/// `poll_fn` shape as [`with_timeout`], but cancelled by another future rather than a timer.
+///
+/// `fut` is polled first, so a future that is already ready wins even if `cancel` is too. When
+/// `cancel` wins, `fut` is dropped mid-poll; every caller is responsible for only passing
+/// futures that tolerate that. The read loop's use of this is why `TransportStream::recv` is
+/// documented as having to be cancel-safe.
+pub(crate) async fn with_cancel<F: Future, C: Future>(
+    fut: F,
+    cancel: C,
+) -> Result<F::Output, Cancelled> {
+    let mut fut = core::pin::pin!(fut);
+    let mut cancel = core::pin::pin!(cancel);
+    core::future::poll_fn(move |cx| {
+        if let Poll::Ready(value) = fut.as_mut().poll(cx) {
+            return Poll::Ready(Ok(value));
+        }
+        if cancel.as_mut().poll(cx).is_ready() {
+            return Poll::Ready(Err(Cancelled));
+        }
+        Poll::Pending
+    })
+    .await
+}
 
 /// Race `fut` against `timer.delay(duration)`, by hand - no `futures::select`/extra
 /// dependency needed, just polling both each wake via `core::future::poll_fn`.

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -8,6 +8,7 @@
 use alloc::collections::VecDeque;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
+use core::sync::atomic::{AtomicBool, Ordering};
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::mutex::Mutex as EmbassyMutex;
 use embassy_sync::signal::Signal;
@@ -50,6 +51,7 @@ impl<T> Clone for OneShot<T> {
 struct ChanInner<T> {
     queue: SharedMutex<VecDeque<T>>,
     signal: Signal<CriticalSectionRawMutex, ()>,
+    closed: AtomicBool,
 }
 
 /// Unbounded multi-producer, single-consumer-ish queue replacing the bounded
@@ -66,6 +68,7 @@ impl<T> Chan<T> {
             inner: Arc::new(ChanInner {
                 queue: SharedMutex::new(VecDeque::new()),
                 signal: Signal::new(),
+                closed: AtomicBool::new(false),
             }),
         }
     }
@@ -78,18 +81,50 @@ impl<T> Chan<T> {
         self.inner.signal.signal(());
     }
 
-    /// Waits for the next queued value. `Signal`'s "latch" semantics (a `signal()` call before
-    /// `wait()` is still observed) make the check-queue-then-wait-then-retry loop race-free.
-    pub(crate) async fn recv(&self) -> T {
+    /// Stop this channel: once whatever is already queued has been drained, `recv` returns
+    /// `None` instead of parking forever.
+    ///
+    /// This exists so a handler task can be retired. `Client::on` replaces the registered
+    /// channel for an action, which leaves the previous task blocked on a channel nothing can
+    /// ever deliver to - it would loop forever, one leaked task per re-registration. Closing the
+    /// channel it holds is what lets it end.
+    pub(crate) fn close(&self) {
+        self.inner.closed.store(true, Ordering::SeqCst);
+        self.inner.signal.signal(());
+    }
+
+    /// Waits for the next queued value, or `None` once the channel is closed and drained.
+    ///
+    /// `Signal`'s "latch" semantics (a `signal()` call before `wait()` is still observed) make
+    /// the check-queue-then-wait-then-retry loop race-free, and mean a `close` racing a `send`
+    /// still wakes the receiver exactly once - it re-reads both the queue and the flag on each
+    /// wake, so a coalesced signal loses nothing.
+    ///
+    /// Draining before reporting closed is deliberate: a retired handler still answers the calls
+    /// that were already dispatched to it, rather than leaving the peer without a reply.
+    pub(crate) async fn recv(&self) -> Option<T> {
         loop {
             {
                 let mut queue = self.inner.queue.lock().await;
                 if let Some(value) = queue.pop_front() {
-                    return value;
+                    return Some(value);
+                }
+                if self.inner.closed.load(Ordering::SeqCst) {
+                    return None;
                 }
             }
             self.inner.signal.wait().await;
         }
+    }
+
+    /// Whether two handles refer to the same channel, so a caller can tell "the registration I
+    /// made" from "a registration someone else replaced it with".
+    ///
+    /// Only `wait_for` needs this, and that is `test`-gated - without the same gate this is dead
+    /// code in every ordinary build, which the embedded CI job (`clippy -D warnings`) rejects.
+    #[cfg(feature = "test")]
+    pub(crate) fn is_same(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
     }
 }
 
@@ -97,6 +132,42 @@ impl<T> Clone for Chan<T> {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
+        }
+    }
+}
+
+/// Single-consumer, repeatable wakeup. Unlike [`OneShot`], `wait` is meant to be called in a
+/// loop: `embassy_sync`'s `Signal` resets itself once its value is taken, so each `notify`
+/// releases exactly one subsequent `wait`. Latching (a `notify` before the matching `wait` is
+/// still observed) means the notifier never has to know whether the waiter is parked yet.
+///
+/// Used for the two "wake this loop up now" edges the keepalive machinery needs: telling the
+/// keepalive task its interval was reconfigured (`Client::set_ping_interval`), and telling the
+/// read loop to abandon the current transport and redial (`Client::force_reconnect`).
+pub(crate) struct Notify {
+    signal: Arc<Signal<CriticalSectionRawMutex, ()>>,
+}
+
+impl Notify {
+    pub(crate) fn new() -> Self {
+        Self {
+            signal: Arc::new(Signal::new()),
+        }
+    }
+
+    pub(crate) fn notify(&self) {
+        self.signal.signal(());
+    }
+
+    pub(crate) async fn wait(&self) {
+        self.signal.wait().await
+    }
+}
+
+impl Clone for Notify {
+    fn clone(&self) -> Self {
+        Self {
+            signal: self.signal.clone(),
         }
     }
 }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -3,6 +3,7 @@ pub(crate) mod websocket;
 
 use alloc::boxed::Box;
 use alloc::string::String;
+use alloc::vec::Vec;
 use core::future::Future;
 use core::pin::Pin;
 
@@ -14,11 +15,16 @@ pub type TransportError = Box<dyn core::error::Error + Send + Sync>;
 /// keepalive event. Carrying ping/pong through the abstraction (rather than hiding it
 /// entirely inside the WebSocket adapter) keeps `send_ping`/`on_ping` possible without the
 /// generic client knowing anything WebSocket-specific.
+///
+/// `Ping`/`Pong` carry the frame's application data, which RFC 6455 §5.5.2-3 requires a pong
+/// to echo back from the ping that triggered it. `Client` relies on that echo to match a pong
+/// to the exact `send_ping` waiting for it, so transport implementations must pass the payload
+/// through rather than discarding it.
 #[derive(Debug)]
 pub enum TransportEvent {
     Frame(String),
-    Ping,
-    Pong,
+    Ping(Vec<u8>),
+    Pong(Vec<u8>),
 }
 
 /// The write half of a transport: sends one complete OCPP-J text frame at a time.
@@ -34,11 +40,19 @@ pub trait TransportSink: Send {
         &'a mut self,
         frame: String,
     ) -> Pin<Box<dyn Future<Output = Result<(), TransportError>> + Send + 'a>>;
+    /// Send a ping carrying `payload` as its application data. `Client` puts a correlation
+    /// token there and matches it against the echoed payload of the pong that comes back, so
+    /// implementations must transmit it verbatim instead of sending an empty ping.
     fn ping<'a>(
         &'a mut self,
+        payload: Vec<u8>,
     ) -> Pin<Box<dyn Future<Output = Result<(), TransportError>> + Send + 'a>>;
+    /// Send a pong carrying `payload`. When replying to a received ping, RFC 6455 requires
+    /// this to be that ping's application data verbatim - the read loop passes it straight
+    /// through from [`TransportEvent::Ping`].
     fn pong<'a>(
         &'a mut self,
+        payload: Vec<u8>,
     ) -> Pin<Box<dyn Future<Output = Result<(), TransportError>> + Send + 'a>>;
     fn close<'a>(
         &'a mut self,
@@ -48,6 +62,19 @@ pub trait TransportSink: Send {
 /// The read half of a transport: yields one [`TransportEvent`] at a time, or `None` when
 /// the other side closed the connection.
 pub trait TransportStream: Send {
+    /// Yield the next event.
+    ///
+    /// **Must be cancel-safe**: the returned future can be dropped before it completes, and
+    /// doing so must not lose or partially consume an event - the next `recv` call has to pick
+    /// up where this one left off. `Client`'s read loop races this against an internal
+    /// "abandon this connection and redial" signal (fired by keepalive when the peer stops
+    /// answering pings), so a stalled `recv` gets dropped mid-poll rather than parking the loop
+    /// until the OS TCP timeout.
+    ///
+    /// The two implementations in the Flowion tree satisfy this because they bottom out in
+    /// already-cancel-safe primitives (`futures::StreamExt::next` over a `tokio-tungstenite`
+    /// stream; an `embassy-net` socket read). An implementation that buffers partial state in a
+    /// local variable across an `.await` needs to move that state into `self` to qualify.
     fn recv<'a>(
         &'a mut self,
     ) -> Pin<Box<dyn Future<Output = Result<Option<TransportEvent>, TransportError>> + Send + 'a>>;

--- a/src/transport/websocket.rs
+++ b/src/transport/websocket.rs
@@ -27,10 +27,11 @@ impl TransportSink for WebSocketSink {
 
     fn ping<'a>(
         &'a mut self,
+        payload: Vec<u8>,
     ) -> Pin<Box<dyn Future<Output = Result<(), TransportError>> + Send + 'a>> {
         Box::pin(async move {
             self.0
-                .send(Message::Ping(Vec::new().into()))
+                .send(Message::Ping(payload.into()))
                 .await
                 .map_err(boxed)
         })
@@ -38,10 +39,11 @@ impl TransportSink for WebSocketSink {
 
     fn pong<'a>(
         &'a mut self,
+        payload: Vec<u8>,
     ) -> Pin<Box<dyn Future<Output = Result<(), TransportError>> + Send + 'a>> {
         Box::pin(async move {
             self.0
-                .send(Message::Pong(Vec::new().into()))
+                .send(Message::Pong(payload.into()))
                 .await
                 .map_err(boxed)
         })
@@ -67,8 +69,12 @@ impl TransportStream for WebSocketSource {
                     Some(Ok(Message::Text(text))) => {
                         Ok(Some(TransportEvent::Frame(text.to_string())))
                     }
-                    Some(Ok(Message::Ping(_))) => Ok(Some(TransportEvent::Ping)),
-                    Some(Ok(Message::Pong(_))) => Ok(Some(TransportEvent::Pong)),
+                    Some(Ok(Message::Ping(payload))) => {
+                        Ok(Some(TransportEvent::Ping(payload.into())))
+                    }
+                    Some(Ok(Message::Pong(payload))) => {
+                        Ok(Some(TransportEvent::Pong(payload.into())))
+                    }
                     Some(Ok(Message::Close(_))) => Ok(None),
                     // Binary/frame frames aren't valid OCPP-J; skip and keep reading.
                     Some(Ok(_)) => continue,

--- a/tests/action_coverage.rs
+++ b/tests/action_coverage.rs
@@ -1,0 +1,179 @@
+//! Guards against the gap that produced a downstream bug report: an OCPP action whose
+//! request/response types exist in `ocpp-types` but which no `ocpp_*_action!` invocation ever
+//! wired up, so callers had no way to send or receive it.
+//!
+//! Five such actions shipped that way and were only noticed when a consumer tried to use them
+//! (see CHANGELOG 0.2.1). Nothing about that was visible at compile time - unwired types are
+//! simply unreferenced - so this test makes it a build failure instead of a bug report.
+//!
+//! It works by comparing action *name strings*, not type names: every action type in
+//! `ocpp-types` carries the wire name as `<Type as ocpp_types::Action>::ACTION`, and every macro
+//! invocation here passes the same string. Rust has no reflection to enumerate types with, so the
+//! `ocpp-types` side is read from its source, located through `cargo metadata` (the crate is laid
+//! out one file per message type, with a single `const ACTION` in each).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Where cargo unpacked the exact `ocpp-types` this crate compiles against.
+fn ocpp_types_src() -> PathBuf {
+    let output = Command::new(std::env::var("CARGO").unwrap_or_else(|_| "cargo".into()))
+        .args(["metadata", "--format-version", "1"])
+        .arg("--manifest-path")
+        .arg(concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml"))
+        .output()
+        .expect("cargo metadata should run inside a cargo test");
+    assert!(
+        output.status.success(),
+        "cargo metadata failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let metadata: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("cargo metadata emits JSON");
+
+    // Match on the package entry, not on the first mention of the name - dependency records carry
+    // the name too, and their enclosing object's manifest_path is the *dependent's*.
+    let manifest = metadata["packages"]
+        .as_array()
+        .expect("metadata has a packages array")
+        .iter()
+        .find(|package| package["name"] == "ocpp-types")
+        .and_then(|package| package["manifest_path"].as_str())
+        .map(PathBuf::from)
+        .expect("ocpp-types should be a dependency of this crate");
+
+    manifest
+        .parent()
+        .expect("manifest has a parent directory")
+        .join("src")
+}
+
+/// Every action name `ocpp-types` defines for `version`, read from the `const ACTION` in each
+/// `*_request.rs`. Request files only: a response carries the same name, and counting both would
+/// just duplicate.
+fn actions_in_ocpp_types(version: &str) -> Vec<String> {
+    let dir = ocpp_types_src().join(version);
+    let entries =
+        std::fs::read_dir(&dir).unwrap_or_else(|e| panic!("could not read {}: {e}", dir.display()));
+
+    let mut actions = Vec::new();
+    for entry in entries {
+        let path = entry.expect("readable dir entry").path();
+        let name = path.file_name().unwrap().to_string_lossy().to_string();
+        if !name.ends_with("_request.rs") {
+            continue;
+        }
+        let source = std::fs::read_to_string(&path).expect("readable source file");
+        if let Some(action) = extract_after(&source, "const ACTION: &'static str = \"") {
+            actions.push(action);
+        }
+    }
+    assert!(
+        !actions.is_empty(),
+        "found no actions in {} - has ocpp-types' layout changed?",
+        dir.display()
+    );
+    actions.sort();
+    actions
+}
+
+/// Every action name wired up in this crate's `actions.rs` for one version, taken from the
+/// name-string argument of each macro invocation.
+fn actions_wired_up(module: &str, macro_name: &str) -> Vec<String> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join(module)
+        .join("actions.rs");
+    let source = std::fs::read_to_string(&path).expect("readable actions.rs");
+
+    let mut actions = Vec::new();
+    for invocation in source.split(&format!("{macro_name}!")).skip(1) {
+        // The name string is the first quoted literal in the invocation - the arguments before it
+        // are all bare identifiers (marker type, request type, response type).
+        let Some(open) = invocation.find('"') else {
+            continue;
+        };
+        let rest = &invocation[open + 1..];
+        let Some(close) = rest.find('"') else {
+            continue;
+        };
+        actions.push(rest[..close].to_string());
+    }
+    actions.sort();
+    actions
+}
+
+fn extract_after(source: &str, key: &str) -> Option<String> {
+    let start = source.find(key)? + key.len();
+    let rest = &source[start..];
+    let end = rest.find('"')?;
+    Some(rest[..end].to_string())
+}
+
+/// `ocpp_*_action!` models a CALL/CALLRESULT pair. Actions that are `SEND`-only (OCPP-J 2.1
+/// message type 6, no response) go through `ocpp_*_send_action!` instead, and their `ocpp-types`
+/// definition has no `*_request.rs` file - so they are wired up without appearing on the
+/// `ocpp-types` side of this comparison.
+fn assert_every_action_is_wired(version: &str, module: &str, macro_prefix: &str) {
+    let available = actions_in_ocpp_types(version);
+    let mut wired = actions_wired_up(module, &format!("{macro_prefix}_action"));
+    wired.extend(actions_wired_up(
+        module,
+        &format!("{macro_prefix}_send_action"),
+    ));
+
+    let missing: Vec<_> = available
+        .iter()
+        .filter(|action| !wired.contains(action))
+        .collect();
+
+    assert!(
+        missing.is_empty(),
+        "{version}: ocpp-types defines these actions but no {macro_prefix}_action! invocation in \
+         src/{module}/actions.rs wires them up, so callers cannot send or receive them: \
+         {missing:?}\n\
+         Add one macro line each (see CLAUDE.md, \"Adding a new OCPP action\").",
+    );
+}
+
+#[cfg(feature = "ocpp_1_6")]
+#[test]
+fn every_ocpp_1_6_action_in_ocpp_types_is_wired_up() {
+    assert_every_action_is_wired("v16", "ocpp_1_6", "ocpp_1_6");
+}
+
+#[cfg(feature = "ocpp_2_0_1")]
+#[test]
+fn every_ocpp_2_0_1_action_in_ocpp_types_is_wired_up() {
+    assert_every_action_is_wired("v201", "ocpp_2_0_1", "ocpp_2_0_1");
+}
+
+#[cfg(feature = "ocpp_2_1")]
+#[test]
+fn every_ocpp_2_1_action_in_ocpp_types_is_wired_up() {
+    assert_every_action_is_wired("v21", "ocpp_2_1", "ocpp_2_1");
+}
+
+/// Sanity check on the scan itself: if either side silently stopped matching anything, the
+/// coverage tests above would pass vacuously.
+#[cfg(feature = "ocpp_2_1")]
+#[test]
+fn the_coverage_scan_actually_finds_actions_on_both_sides() {
+    let available = actions_in_ocpp_types("v21");
+    let wired = actions_wired_up("ocpp_2_1", "ocpp_2_1_action");
+
+    assert!(
+        available.len() > 80,
+        "expected ~90 actions in ocpp-types v21, found {}",
+        available.len()
+    );
+    assert!(
+        wired.len() > 80,
+        "expected ~90 wired actions in src/ocpp_2_1/actions.rs, found {}",
+        wired.len()
+    );
+    assert!(
+        available.contains(&"GetDERControl".to_string()),
+        "the scan should see GetDERControl - one of the five actions this test exists because of"
+    );
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,3 +1,8 @@
+// `tests/*.rs` files are each their own crate, and each one gets its own copy of this module.
+// No single test crate uses every helper here, so unused-item warnings are expected rather than
+// a sign of dead code.
+#![allow(dead_code)]
+
 use ocpp_client::{TransportError, TransportEvent, TransportSink, TransportStream};
 use std::future::Future;
 use std::pin::Pin;
@@ -8,6 +13,28 @@ use tokio::sync::mpsc;
 /// out the other.
 pub struct FakeSink(mpsc::UnboundedSender<TransportEvent>);
 pub struct FakeSource(mpsc::UnboundedReceiver<TransportEvent>);
+
+impl FakeSink {
+    /// Push a raw event into this end of the pair, for events the `TransportSink` API can't
+    /// produce - an unsolicited pong, say.
+    pub fn send_event(&self, event: TransportEvent) {
+        self.0.send(event).expect("other end still open");
+    }
+
+    /// Another handle on the same channel. The fake sink is only an `UnboundedSender`, so a test
+    /// can keep one for injection while handing another to `spawn_peer`.
+    pub fn duplicate(&self) -> FakeSink {
+        FakeSink(self.0.clone())
+    }
+}
+
+impl FakeSource {
+    /// Read the next event directly, bypassing `Client`, so a test can assert on what the client
+    /// actually put on the wire.
+    pub async fn recv_event(&mut self) -> Option<TransportEvent> {
+        self.0.recv().await
+    }
+}
 
 impl TransportSink for FakeSink {
     fn send<'a>(
@@ -23,20 +50,22 @@ impl TransportSink for FakeSink {
 
     fn ping<'a>(
         &'a mut self,
+        payload: Vec<u8>,
     ) -> Pin<Box<dyn Future<Output = Result<(), TransportError>> + Send + 'a>> {
         Box::pin(async move {
             self.0
-                .send(TransportEvent::Ping)
+                .send(TransportEvent::Ping(payload))
                 .map_err(|e| Box::new(e) as TransportError)
         })
     }
 
     fn pong<'a>(
         &'a mut self,
+        payload: Vec<u8>,
     ) -> Pin<Box<dyn Future<Output = Result<(), TransportError>> + Send + 'a>> {
         Box::pin(async move {
             self.0
-                .send(TransportEvent::Pong)
+                .send(TransportEvent::Pong(payload))
                 .map_err(|e| Box::new(e) as TransportError)
         })
     }
@@ -64,4 +93,49 @@ pub fn fake_transport_pair() -> ((FakeSink, FakeSource), (FakeSink, FakeSource))
         (FakeSink(a_tx), FakeSource(b_rx)),
         (FakeSink(b_tx), FakeSource(a_rx)),
     )
+}
+
+/// How a test peer answers the pings the client sends it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PongBehavior {
+    /// Answer every ping with a pong echoing its payload, as RFC 6455 requires.
+    Echo,
+    /// Never answer. Models a half-open connection: the socket still accepts writes, but
+    /// nothing comes back.
+    Silent,
+    /// Answer, but with an empty payload instead of the ping's. Models a non-compliant peer,
+    /// and pins down that correlation is by payload rather than by arrival order.
+    WrongPayload,
+}
+
+/// Drives the peer end of a [`fake_transport_pair`], answering pings per `behavior`.
+///
+/// Returns a receiver yielding the payload of every ping the client sent, so a test can count
+/// pings and assert on their correlation tokens without reaching into the client.
+pub fn spawn_peer(
+    sink: FakeSink,
+    source: FakeSource,
+    behavior: PongBehavior,
+) -> mpsc::UnboundedReceiver<Vec<u8>> {
+    let (observed_tx, observed_rx) = mpsc::unbounded_channel();
+    let mut source = source;
+    tokio::spawn(async move {
+        while let Some(event) = source.0.recv().await {
+            if let TransportEvent::Ping(payload) = event {
+                if observed_tx.send(payload.clone()).is_err() {
+                    break;
+                }
+                match behavior {
+                    PongBehavior::Echo => {
+                        let _ = sink.0.send(TransportEvent::Pong(payload));
+                    }
+                    PongBehavior::WrongPayload => {
+                        let _ = sink.0.send(TransportEvent::Pong(Vec::new()));
+                    }
+                    PongBehavior::Silent => {}
+                }
+            }
+        }
+    });
+    observed_rx
 }

--- a/tests/ocpp_1_6_bookkeeping.rs
+++ b/tests/ocpp_1_6_bookkeeping.rs
@@ -1,0 +1,309 @@
+//! The client's internal tables must not grow without bound, and superseded handler tasks must
+//! actually stop.
+//!
+//! None of this is observable from ordinary use - a leaked map entry or a task looping forever on
+//! a channel nobody writes to shows up only as memory growth on a charge point that has been up
+//! for weeks. So these use the `test`-feature accessors and a drop-detecting callback.
+#![cfg(feature = "test")]
+
+mod common;
+
+use common::{PongBehavior, fake_transport_pair, spawn_peer};
+use ocpp_client::ocpp_1_6::{Heartbeat, OCPP1_6Client};
+use ocpp_client::{Client, ClientConfig, ClientError, TokioExecutor, TokioTimer, TransportEvent};
+use ocpp_types::v16::{HeartbeatRequest, HeartbeatResponse};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+use tokio::sync::mpsc;
+use tokio::time::timeout;
+
+const GENEROUS: Duration = Duration::from_secs(5);
+
+/// A client whose peer answers pings but never answers CALLs, so every request times out.
+fn client_that_never_gets_answers() -> OCPP1_6Client {
+    let ((client_sink, client_source), (peer_sink, peer_source)) = fake_transport_pair();
+    // Leaked on purpose: the peer must stay alive for the client's whole life.
+    Box::leak(Box::new(spawn_peer(
+        peer_sink,
+        peer_source,
+        PongBehavior::Echo,
+    )));
+    Client::from_transport_with_config(
+        Box::new(client_sink),
+        Box::new(client_source),
+        Box::new(TokioExecutor),
+        Box::new(TokioTimer),
+        ClientConfig::new(Duration::from_millis(50)),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// 1. pending_responses
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_timed_out_request_does_not_leak_its_pending_entry() {
+    let client = client_that_never_gets_answers();
+    assert_eq!(client.pending_request_count().await, 0);
+
+    let result = client.send_heartbeat(HeartbeatRequest {}).await;
+    assert!(matches!(result, Err(ClientError::Timeout)));
+
+    assert_eq!(
+        client.pending_request_count().await,
+        0,
+        "a request that gave up must remove its own waiter, or the table grows forever"
+    );
+}
+
+#[tokio::test]
+async fn many_timed_out_requests_do_not_accumulate() {
+    let client = client_that_never_gets_answers();
+
+    for _ in 0..25 {
+        let _ = client.send_heartbeat(HeartbeatRequest {}).await;
+    }
+
+    assert_eq!(
+        client.pending_request_count().await,
+        0,
+        "25 timed-out requests should leave nothing behind"
+    );
+}
+
+#[tokio::test]
+async fn a_request_that_could_not_be_sent_does_not_leak_its_pending_entry() {
+    let ((client_sink, client_source), (peer_sink, peer_source)) = fake_transport_pair();
+    drop(peer_source); // every send on the client's sink now fails
+    drop(peer_sink);
+
+    let client: OCPP1_6Client = Client::from_transport_with_config(
+        Box::new(client_sink),
+        Box::new(client_source),
+        Box::new(TokioExecutor),
+        Box::new(TokioTimer),
+        ClientConfig::new(Duration::from_millis(50)),
+    );
+
+    let result = client.send_heartbeat(HeartbeatRequest {}).await;
+    assert!(
+        matches!(result, Err(ClientError::Transport(_))),
+        "expected a transport error, got {result:?}"
+    );
+    assert_eq!(
+        client.pending_request_count().await,
+        0,
+        "a request that never made it onto the wire must clean up after itself too"
+    );
+}
+
+/// The equivalent guarantee for pings, which was fixed earlier - here so the two tables are
+/// covered by the same suite and neither regresses silently.
+#[tokio::test]
+async fn a_timed_out_ping_does_not_leak_its_waiter() {
+    let ((client_sink, client_source), (peer_sink, peer_source)) = fake_transport_pair();
+    Box::leak(Box::new(spawn_peer(
+        peer_sink,
+        peer_source,
+        PongBehavior::Silent,
+    )));
+    let client: OCPP1_6Client = Client::from_transport_with_config(
+        Box::new(client_sink),
+        Box::new(client_source),
+        Box::new(TokioExecutor),
+        Box::new(TokioTimer),
+        ClientConfig::new(Duration::from_millis(50)),
+    );
+
+    assert!(matches!(
+        client.send_ping().await,
+        Err(ClientError::Timeout)
+    ));
+    assert_eq!(client.pending_ping_count().await, 0);
+}
+
+// ---------------------------------------------------------------------------
+// 2. superseded `on()` handlers
+// ---------------------------------------------------------------------------
+
+/// Signals on drop, so a test can observe that the task owning it has actually ended.
+struct DropSignal(Option<mpsc::UnboundedSender<()>>);
+
+impl Drop for DropSignal {
+    fn drop(&mut self) {
+        if let Some(tx) = self.0.take() {
+            let _ = tx.send(());
+        }
+    }
+}
+
+#[tokio::test]
+async fn replacing_a_handler_stops_the_previous_handler_task() {
+    let client = client_that_never_gets_answers();
+
+    let (dropped_tx, mut dropped) = mpsc::unbounded_channel();
+    let guard = DropSignal(Some(dropped_tx));
+    client
+        .on::<Heartbeat, _, _>(move |_req, _client| {
+            // Captured so the guard lives exactly as long as this task's future.
+            let _ = &guard;
+            async move {
+                Ok(HeartbeatResponse {
+                    current_time: "2024-01-01T00:00:00Z".into(),
+                })
+            }
+        })
+        .await;
+
+    assert!(
+        dropped.try_recv().is_err(),
+        "the handler task should still be running before it is replaced"
+    );
+
+    // Replace it. The old task is now unreachable - nothing can ever deliver to its channel.
+    client
+        .on::<Heartbeat, _, _>(|_req, _client| async move {
+            Ok(HeartbeatResponse {
+                current_time: "2024-01-01T00:00:00Z".into(),
+            })
+        })
+        .await;
+
+    timeout(GENEROUS, dropped.recv())
+        .await
+        .expect("the superseded handler task must exit, not loop forever on a dead channel")
+        .expect("drop signal sender still alive");
+}
+
+#[tokio::test]
+async fn the_replacement_handler_is_the_one_that_answers() {
+    let ((client_sink, client_source), (peer_sink, mut peer_source)) = fake_transport_pair();
+    let client: OCPP1_6Client = Client::from_transport_with_config(
+        Box::new(client_sink),
+        Box::new(client_source),
+        Box::new(TokioExecutor),
+        Box::new(TokioTimer),
+        ClientConfig::new(Duration::from_millis(200)),
+    );
+
+    let first_calls = Arc::new(AtomicUsize::new(0));
+    let second_calls = Arc::new(AtomicUsize::new(0));
+
+    let counter = first_calls.clone();
+    client
+        .on::<Heartbeat, _, _>(move |_req, _client| {
+            let counter = counter.clone();
+            async move {
+                counter.fetch_add(1, Ordering::SeqCst);
+                Ok(HeartbeatResponse {
+                    current_time: "2024-01-01T00:00:00Z".into(),
+                })
+            }
+        })
+        .await;
+
+    let counter = second_calls.clone();
+    client
+        .on::<Heartbeat, _, _>(move |_req, _client| {
+            let counter = counter.clone();
+            async move {
+                counter.fetch_add(1, Ordering::SeqCst);
+                Ok(HeartbeatResponse {
+                    current_time: "2024-01-01T00:00:00Z".into(),
+                })
+            }
+        })
+        .await;
+
+    peer_sink.send_event(TransportEvent::Frame(
+        r#"[2,"m1","Heartbeat",{}]"#.to_string(),
+    ));
+
+    timeout(GENEROUS, peer_source.recv_event())
+        .await
+        .expect("the client should answer the call")
+        .expect("peer end still open");
+
+    assert_eq!(second_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        first_calls.load(Ordering::SeqCst),
+        0,
+        "the replaced handler must not run"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. wait_for leaves the action registered
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn wait_for_unregisters_so_later_calls_are_not_swallowed() {
+    let ((client_sink, client_source), (peer_sink, mut peer_source)) = fake_transport_pair();
+    let client: OCPP1_6Client = Client::from_transport_with_config(
+        Box::new(client_sink),
+        Box::new(client_source),
+        Box::new(TokioExecutor),
+        Box::new(TokioTimer),
+        ClientConfig::new(Duration::from_millis(300)),
+    );
+
+    let waiting = {
+        let client = client.clone();
+        tokio::spawn(async move {
+            client
+                .wait_for::<Heartbeat, _, _>(|_req, _client| async move {
+                    Ok(HeartbeatResponse {
+                        current_time: "2024-01-01T00:00:00Z".into(),
+                    })
+                })
+                .await
+        })
+    };
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    peer_sink.send_event(TransportEvent::Frame(
+        r#"[2,"m1","Heartbeat",{}]"#.to_string(),
+    ));
+
+    // The CALLRESULT for the awaited call.
+    let first = timeout(GENEROUS, peer_source.recv_event())
+        .await
+        .expect("wait_for should answer the call it was waiting for")
+        .expect("peer end still open");
+    match first {
+        TransportEvent::Frame(frame) => assert!(frame.starts_with("[3,"), "expected a CALLRESULT"),
+        other => panic!("expected a frame, got {other:?}"),
+    }
+
+    timeout(GENEROUS, waiting)
+        .await
+        .expect("wait_for should return")
+        .expect("task should not panic")
+        .expect("wait_for should have parsed the request");
+
+    // A second call for the same action. With the registration left behind, this went into a
+    // channel nobody reads and the CSMS got no answer at all - not even an error.
+    peer_sink.send_event(TransportEvent::Frame(
+        r#"[2,"m2","Heartbeat",{}]"#.to_string(),
+    ));
+
+    let second = timeout(Duration::from_secs(2), peer_source.recv_event())
+        .await
+        .expect("a call with no registered handler must still be answered, not swallowed")
+        .expect("peer end still open");
+
+    match second {
+        TransportEvent::Frame(frame) => {
+            assert!(
+                frame.starts_with("[4,"),
+                "expected a CALLERROR for an unhandled action, got {frame}"
+            );
+            assert!(
+                frame.contains("NotImplemented"),
+                "expected NotImplemented, got {frame}"
+            );
+        }
+        other => panic!("expected a frame, got {other:?}"),
+    }
+}

--- a/tests/ocpp_1_6_custom_reconnector.rs
+++ b/tests/ocpp_1_6_custom_reconnector.rs
@@ -105,6 +105,7 @@ async fn a_custom_reconnector_redials_an_address_the_client_was_never_given() {
             initial_delay: Duration::from_millis(20),
             max_delay: Duration::from_millis(100),
             multiplier: 2,
+            jitter: false,
         }),
         reconnector: Some(Arc::new(SwitchableReconnector {
             address: target.clone(),

--- a/tests/ocpp_1_6_disconnect.rs
+++ b/tests/ocpp_1_6_disconnect.rs
@@ -1,0 +1,306 @@
+//! `disconnect()` must actually disconnect - and stay disconnected.
+//!
+//! The race this pins down: `disconnect()` closed the sink, the read loop saw the resulting EOF,
+//! and (with reconnect enabled, which is the default) treated it as a dropped connection and
+//! redialled. So an explicit shutdown got silently undone, and on the default `ConnectOptions` a
+//! caller had no way to stop a client at all.
+//!
+//! The first test uses a real socket, because that is where the bug actually reproduces: the
+//! in-memory fake's `close()` doesn't end the peer's stream, so the read loop never saw the EOF
+//! that triggered the redial. The rest use the fake transport for the surrounding behavior.
+#![allow(clippy::result_large_err)]
+
+mod common;
+
+use common::{PongBehavior, fake_transport_pair, spawn_peer};
+use ocpp_client::ocpp_1_6::OCPP1_6Client;
+use ocpp_client::{
+    Client, ClientConfig, ClientError, KeepaliveBehavior, KeepalivePolicy, ReconnectPolicy,
+    Reconnector, TokioExecutor, TokioTimer, TransportError, TransportSink, TransportStream,
+    connect_1_6,
+};
+use ocpp_types::v16::HeartbeatRequest;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+use tokio::net::TcpListener;
+use tokio::sync::Mutex;
+
+/// Longer than `ReconnectPolicy::default()`'s 1s initial backoff, so a client that was going to
+/// redial has had time to do it.
+const PAST_FIRST_RETRY: Duration = Duration::from_millis(2500);
+
+#[tokio::test]
+async fn disconnect_does_not_redial_even_though_reconnect_is_enabled() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connections = Arc::new(AtomicUsize::new(0));
+
+    let accepted = connections.clone();
+    tokio::spawn(async move {
+        // Keeps accepting, so a redial would succeed and be counted rather than being refused.
+        loop {
+            let Ok((tcp, _)) = listener.accept().await else {
+                break;
+            };
+            accepted.fetch_add(1, Ordering::SeqCst);
+            tokio::spawn(async move {
+                let Ok(mut ws) = tokio_tungstenite::accept_hdr_async(
+                    tcp,
+                    |_req: &tokio_tungstenite::tungstenite::handshake::server::Request,
+                     mut response: tokio_tungstenite::tungstenite::handshake::server::Response| {
+                        response
+                            .headers_mut()
+                            .insert("Sec-WebSocket-Protocol", "ocpp1.6".parse().unwrap());
+                        Ok(response)
+                    },
+                )
+                .await
+                else {
+                    return;
+                };
+                // Hold the connection open. Dropping it here instead would make the server close
+                // every connection the instant it opened, so a regression would show up as a hot
+                // reconnect loop rather than the single unwanted redial this test is looking for.
+                use futures::StreamExt;
+                while let Some(Ok(message)) = ws.next().await {
+                    if matches!(message, tokio_tungstenite::tungstenite::Message::Close(_)) {
+                        break;
+                    }
+                }
+            });
+        }
+    });
+
+    // `None` means the defaults, which include reconnect enabled - the configuration the race
+    // needed.
+    let client = connect_1_6(&format!("ws://{addr}"), None).await.unwrap();
+    assert_eq!(connections.load(Ordering::SeqCst), 1, "initial connection");
+
+    client.disconnect().await.unwrap();
+    tokio::time::sleep(PAST_FIRST_RETRY).await;
+
+    assert_eq!(
+        connections.load(Ordering::SeqCst),
+        1,
+        "disconnect() must not be undone by the reconnector"
+    );
+}
+
+/// Hands out a fresh loopback transport on every redial, counting them.
+struct CountingReconnector {
+    calls: Arc<AtomicUsize>,
+    keep: Mutex<Vec<tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>>>,
+}
+
+impl Reconnector for CountingReconnector {
+    fn connect<'a>(
+        &'a self,
+    ) -> Pin<
+        Box<
+            dyn Future<
+                    Output = Result<
+                        (Box<dyn TransportSink>, Box<dyn TransportStream>),
+                        TransportError,
+                    >,
+                > + Send
+                + 'a,
+        >,
+    > {
+        Box::pin(async move {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let ((client_sink, client_source), (peer_sink, peer_source)) = fake_transport_pair();
+            let observed = spawn_peer(peer_sink, peer_source, PongBehavior::Echo);
+            self.keep.lock().await.push(observed);
+            Ok((
+                Box::new(client_sink) as Box<dyn TransportSink>,
+                Box::new(client_source) as Box<dyn TransportStream>,
+            ))
+        })
+    }
+}
+
+/// A client with reconnect and fast keepalive, over the fake transport.
+fn client_with_everything_on() -> (
+    OCPP1_6Client,
+    Arc<AtomicUsize>,
+    tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>,
+) {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let ((client_sink, client_source), (peer_sink, peer_source)) = fake_transport_pair();
+    let pings = spawn_peer(peer_sink, peer_source, PongBehavior::Echo);
+
+    let config = ClientConfig::new(Duration::from_millis(200))
+        .with_reconnect(
+            Box::new(CountingReconnector {
+                calls: calls.clone(),
+                keep: Mutex::new(Vec::new()),
+            }),
+            ReconnectPolicy::default(),
+        )
+        .with_keepalive(KeepaliveBehavior::Enabled(KeepalivePolicy::every(
+            Duration::from_millis(20),
+        )));
+
+    let client = Client::from_transport_with_config(
+        Box::new(client_sink),
+        Box::new(client_source),
+        Box::new(TokioExecutor),
+        Box::new(TokioTimer),
+        config,
+    );
+    (client, calls, pings)
+}
+
+#[tokio::test]
+async fn disconnect_stops_the_keepalive_pings() {
+    let (client, _calls, mut pings) = client_with_everything_on();
+
+    // Confirm it really was pinging first, so the assertion below isn't vacuous.
+    tokio::time::timeout(Duration::from_secs(5), pings.recv())
+        .await
+        .expect("should be pinging before disconnect")
+        .expect("peer task still running");
+
+    client.disconnect().await.unwrap();
+
+    // Drain whatever was already in flight when the disconnect landed, then require silence.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    while pings.try_recv().is_ok() {}
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(300), pings.recv())
+            .await
+            .is_err(),
+        "a disconnected client must not keep pinging"
+    );
+}
+
+#[tokio::test]
+async fn disconnect_is_idempotent() {
+    let (client, calls, _pings) = client_with_everything_on();
+
+    client.disconnect().await.expect("first disconnect");
+    client.disconnect().await.expect("second disconnect");
+    client.disconnect().await.expect("third disconnect");
+
+    tokio::time::sleep(PAST_FIRST_RETRY).await;
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        0,
+        "no redial from any of them"
+    );
+}
+
+#[tokio::test]
+async fn force_reconnect_after_disconnect_does_nothing() {
+    let (client, calls, _pings) = client_with_everything_on();
+
+    client.disconnect().await.unwrap();
+    client.force_reconnect();
+
+    tokio::time::sleep(PAST_FIRST_RETRY).await;
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        0,
+        "an explicit disconnect outranks a forced reconnect"
+    );
+}
+
+#[tokio::test]
+async fn is_closed_reports_the_explicit_shutdown() {
+    let (client, _calls, _pings) = client_with_everything_on();
+
+    assert!(!client.is_closed());
+    client.disconnect().await.unwrap();
+    assert!(client.is_closed());
+}
+
+#[tokio::test]
+async fn requests_after_disconnect_fail_fast_as_closed() {
+    let (client, _calls, _pings) = client_with_everything_on();
+    client.disconnect().await.unwrap();
+
+    // Would otherwise sit until the request timeout waiting for a response that can't arrive.
+    let result = tokio::time::timeout(
+        Duration::from_millis(100),
+        client.send_heartbeat(HeartbeatRequest {}),
+    )
+    .await
+    .expect("should fail immediately, not wait out the timeout");
+
+    assert!(
+        matches!(result, Err(ClientError::Closed)),
+        "expected ClientError::Closed, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn pings_after_disconnect_fail_fast_as_closed() {
+    let (client, _calls, _pings) = client_with_everything_on();
+    client.disconnect().await.unwrap();
+
+    let result = tokio::time::timeout(Duration::from_millis(100), client.send_ping())
+        .await
+        .expect("should fail immediately");
+
+    assert!(matches!(result, Err(ClientError::Closed)));
+}
+
+#[tokio::test]
+async fn set_ping_interval_cannot_revive_a_disconnected_client() {
+    let (client, _calls, mut pings) = client_with_everything_on();
+    client.disconnect().await.unwrap();
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    while pings.try_recv().is_ok() {}
+
+    client.set_ping_interval(Some(Duration::from_millis(20)));
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(300), pings.recv())
+            .await
+            .is_err(),
+        "reconfiguring keepalive must not restart a client the caller shut down"
+    );
+}
+
+/// The other half of the guarantee: fixing the explicit-disconnect race must not stop a genuine
+/// drop from being redialled. (`tests/ocpp_1_6_reconnect.rs` covers this over a real socket; this
+/// is the fake-transport version, alongside the disconnect cases it contrasts with.)
+#[tokio::test]
+async fn an_unrequested_drop_still_redials() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let ((client_sink, client_source), (peer_sink, peer_source)) = fake_transport_pair();
+    drop(peer_source);
+
+    let config = ClientConfig::new(Duration::from_millis(200)).with_reconnect(
+        Box::new(CountingReconnector {
+            calls: calls.clone(),
+            keep: Mutex::new(Vec::new()),
+        }),
+        ReconnectPolicy::default(),
+    );
+
+    let _client: OCPP1_6Client = Client::from_transport_with_config(
+        Box::new(client_sink),
+        Box::new(client_source),
+        Box::new(TokioExecutor),
+        Box::new(TokioTimer),
+        config,
+    );
+
+    // Dropping the peer's sink ends the client's inbound stream: an EOF nobody asked for.
+    drop(peer_sink);
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while calls.load(Ordering::SeqCst) == 0 {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "an unrequested EOF should still be redialled"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}

--- a/tests/ocpp_1_6_keepalive.rs
+++ b/tests/ocpp_1_6_keepalive.rs
@@ -1,0 +1,530 @@
+//! Ping/pong and scheduled-keepalive behavior, over the in-memory fake transport.
+//!
+//! Version-independent - all of this lives in the generic `Client<E>` engine - so it is only
+//! mirrored under 1.6 rather than duplicated per version, same rationale as the real-transport
+//! tests being one-per-version-plus-transport.
+//!
+//! Intervals here are milliseconds rather than the production 60 seconds, and assertions use
+//! generous upper bounds (`timeout(...)` around a channel read) instead of measuring elapsed
+//! time, so they stay honest under CI load without needing a mock clock.
+
+mod common;
+
+use common::{PongBehavior, fake_transport_pair, spawn_peer};
+use ocpp_client::ocpp_1_6::OCPP1_6Client;
+use ocpp_client::{
+    Client, ClientConfig, ClientError, KeepaliveBehavior, KeepalivePolicy, Reconnector,
+    TokioExecutor, TokioTimer, TransportError, TransportEvent, TransportSink, TransportStream,
+};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+use tokio::sync::Mutex;
+use tokio::time::timeout;
+
+/// Long enough that a correct implementation always makes it, short enough that a hung test
+/// fails fast rather than hitting the harness timeout.
+const GENEROUS: Duration = Duration::from_secs(5);
+
+fn client_with(config: ClientConfig, behavior: PongBehavior) -> (OCPP1_6Client, PingLog) {
+    let ((client_sink, client_source), (peer_sink, peer_source)) = fake_transport_pair();
+    let observed = spawn_peer(peer_sink, peer_source, behavior);
+    let client = Client::from_transport_with_config(
+        Box::new(client_sink),
+        Box::new(client_source),
+        Box::new(TokioExecutor),
+        Box::new(TokioTimer),
+        config,
+    );
+    (client, observed)
+}
+
+type PingLog = tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>;
+
+// ---------------------------------------------------------------------------
+// Baseline: the manual one-shot ping. Previously untested entirely.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn send_ping_resolves_when_the_peer_echoes_the_pong() {
+    let (client, _pings) = client_with(
+        ClientConfig::new(Duration::from_secs(1)),
+        PongBehavior::Echo,
+    );
+
+    timeout(GENEROUS, client.send_ping())
+        .await
+        .expect("send_ping should not hang")
+        .expect("an echoed pong should resolve the ping");
+}
+
+#[tokio::test]
+async fn send_ping_times_out_when_the_peer_never_answers() {
+    let (client, _pings) = client_with(
+        ClientConfig::new(Duration::from_millis(100)),
+        PongBehavior::Silent,
+    );
+
+    let result = timeout(GENEROUS, client.send_ping())
+        .await
+        .expect("send_ping should give up on its own, not hang");
+
+    assert!(matches!(result, Err(ClientError::Timeout)));
+}
+
+#[tokio::test]
+async fn send_ping_carries_a_correlation_token_as_its_payload() {
+    let (client, mut pings) = client_with(
+        ClientConfig::new(Duration::from_secs(1)),
+        PongBehavior::Echo,
+    );
+
+    client.send_ping().await.expect("ping should be answered");
+    let payload = timeout(GENEROUS, pings.recv())
+        .await
+        .expect("a ping should have reached the peer")
+        .expect("peer task still running");
+
+    assert_eq!(
+        payload.len(),
+        8,
+        "the ping payload should be the 8-byte correlation token, got {payload:?}"
+    );
+}
+
+#[tokio::test]
+async fn an_inbound_ping_is_answered_with_a_pong_echoing_its_payload() {
+    let ((client_sink, client_source), (peer_sink, mut peer_source)) = fake_transport_pair();
+    let _client: OCPP1_6Client = Client::from_transport(
+        Box::new(client_sink),
+        Box::new(client_source),
+        Duration::from_secs(1),
+        Box::new(TokioExecutor),
+        Box::new(TokioTimer),
+    );
+
+    peer_sink.send_event(TransportEvent::Ping(vec![7, 8, 9]));
+
+    let event = timeout(GENEROUS, peer_source.recv_event())
+        .await
+        .expect("the client should answer an inbound ping")
+        .expect("peer end still open");
+
+    match event {
+        TransportEvent::Pong(payload) => assert_eq!(
+            payload,
+            vec![7, 8, 9],
+            "RFC 6455 requires the pong to echo the ping's payload"
+        ),
+        other => panic!("expected a Pong, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Regressions: the pong-matching bugs a scheduled keepalive would have hit.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_timed_out_ping_does_not_poison_later_pings() {
+    // Under the old positional matching this was a permanent failure: the timed-out ping left
+    // its waiter queued, so every subsequent pong resolved a corpse and every subsequent ping
+    // timed out in turn.
+    let ((client_sink, client_source), (peer_sink, peer_source)) = fake_transport_pair();
+    let answer = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+    // A peer that ignores the first ping and echoes every one after it.
+    let answering = answer.clone();
+    let mut source = peer_source;
+    let sink = peer_sink;
+    tokio::spawn(async move {
+        while let Some(event) = source.recv_event().await {
+            if let TransportEvent::Ping(payload) = event
+                && answering.load(Ordering::SeqCst)
+            {
+                sink.send_event(TransportEvent::Pong(payload));
+            }
+        }
+    });
+
+    let client: OCPP1_6Client = Client::from_transport(
+        Box::new(client_sink),
+        Box::new(client_source),
+        Duration::from_millis(100),
+        Box::new(TokioExecutor),
+        Box::new(TokioTimer),
+    );
+
+    assert!(
+        matches!(client.send_ping().await, Err(ClientError::Timeout)),
+        "first ping is deliberately unanswered"
+    );
+
+    answer.store(true, Ordering::SeqCst);
+
+    timeout(GENEROUS, client.send_ping())
+        .await
+        .expect("second ping should not hang")
+        .expect("second ping should be answered despite the first having timed out");
+}
+
+#[tokio::test]
+async fn an_unsolicited_pong_does_not_satisfy_an_in_flight_ping() {
+    let ((client_sink, client_source), (peer_sink, peer_source)) = fake_transport_pair();
+    // Peer never answers pings, but does send one unsolicited pong.
+    let _observed = spawn_peer(peer_sink.duplicate(), peer_source, PongBehavior::Silent);
+
+    let client: OCPP1_6Client = Client::from_transport(
+        Box::new(client_sink),
+        Box::new(client_source),
+        Duration::from_millis(300),
+        Box::new(TokioExecutor),
+        Box::new(TokioTimer),
+    );
+
+    // Eight bytes, so it exercises the token-parsing path, but a value the monotonic counter
+    // would need 2^64 pings to reach - unlike `vec![0; 8]`, which is genuinely the first ping's
+    // token and would make this test pass for the wrong reason.
+    peer_sink.send_event(TransportEvent::Pong(vec![0xff; 8]));
+
+    let result = timeout(GENEROUS, client.send_ping())
+        .await
+        .expect("send_ping should not hang");
+
+    assert!(
+        matches!(result, Err(ClientError::Timeout)),
+        "an unsolicited pong must not be mistaken for the answer to our ping"
+    );
+}
+
+#[tokio::test]
+async fn a_pong_echoing_the_wrong_payload_does_not_resolve_the_ping() {
+    let (client, _pings) = client_with(
+        ClientConfig::new(Duration::from_millis(300)),
+        PongBehavior::WrongPayload,
+    );
+
+    let result = timeout(GENEROUS, client.send_ping())
+        .await
+        .expect("send_ping should not hang");
+
+    assert!(
+        matches!(result, Err(ClientError::Timeout)),
+        "correlation is by payload, so a non-echoing peer's pong must not count"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The scheduled keepalive loop.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn keepalive_pings_repeatedly_on_the_configured_interval() {
+    let config = ClientConfig::new(Duration::from_secs(1)).with_keepalive(
+        KeepaliveBehavior::Enabled(KeepalivePolicy::every(Duration::from_millis(20))),
+    );
+    let (_client, mut pings) = client_with(config, PongBehavior::Echo);
+
+    for nth in 0..3 {
+        timeout(GENEROUS, pings.recv())
+            .await
+            .unwrap_or_else(|_| panic!("keepalive ping {nth} never arrived"))
+            .expect("peer task still running");
+    }
+}
+
+#[tokio::test]
+async fn keepalive_tokens_differ_between_pings() {
+    let config = ClientConfig::new(Duration::from_secs(1)).with_keepalive(
+        KeepaliveBehavior::Enabled(KeepalivePolicy::every(Duration::from_millis(20))),
+    );
+    let (_client, mut pings) = client_with(config, PongBehavior::Echo);
+
+    let first = timeout(GENEROUS, pings.recv()).await.unwrap().unwrap();
+    let second = timeout(GENEROUS, pings.recv()).await.unwrap().unwrap();
+
+    assert_ne!(
+        first, second,
+        "each ping needs its own token, or two in flight at once could not be told apart"
+    );
+}
+
+#[tokio::test]
+async fn keepalive_is_off_by_default_on_the_bare_constructor() {
+    let (_client, mut pings) = client_with(
+        ClientConfig::new(Duration::from_millis(50)),
+        PongBehavior::Echo,
+    );
+
+    let result = timeout(Duration::from_millis(300), pings.recv()).await;
+    assert!(
+        result.is_err(),
+        "from_transport should not put background traffic on a caller-supplied transport"
+    );
+}
+
+#[tokio::test]
+async fn a_zero_interval_disables_pinging() {
+    let config = ClientConfig::new(Duration::from_secs(1)).with_keepalive(
+        KeepaliveBehavior::Enabled(KeepalivePolicy::every(Duration::ZERO)),
+    );
+    let (client, mut pings) = client_with(config, PongBehavior::Echo);
+
+    assert_eq!(
+        client.ping_interval(),
+        None,
+        "OCPP reads a WebSocketPingInterval of 0 as disabled"
+    );
+    assert!(
+        timeout(Duration::from_millis(300), pings.recv())
+            .await
+            .is_err(),
+        "a zero interval must not ping"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Runtime reconfiguration - the WebSocketPingInterval read/write path.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn ping_interval_reports_the_configured_value() {
+    let config = ClientConfig::new(Duration::from_secs(1)).with_keepalive(
+        KeepaliveBehavior::Enabled(KeepalivePolicy::every(Duration::from_secs(90))),
+    );
+    let (client, _pings) = client_with(config, PongBehavior::Echo);
+
+    assert_eq!(client.ping_interval(), Some(Duration::from_secs(90)));
+}
+
+#[tokio::test]
+async fn set_ping_interval_round_trips_through_the_getter() {
+    let (client, _pings) = client_with(
+        ClientConfig::new(Duration::from_secs(1)),
+        PongBehavior::Echo,
+    );
+
+    assert_eq!(client.ping_interval(), None);
+
+    client.set_ping_interval(Some(Duration::from_secs(30)));
+    assert_eq!(client.ping_interval(), Some(Duration::from_secs(30)));
+
+    client.set_ping_interval(Some(Duration::ZERO));
+    assert_eq!(
+        client.ping_interval(),
+        None,
+        "a CSMS writing 0 should read back as disabled, not as a zero-length interval"
+    );
+
+    client.set_ping_interval(Some(Duration::from_secs(30)));
+    client.set_ping_interval(None);
+    assert_eq!(client.ping_interval(), None);
+}
+
+#[tokio::test]
+async fn set_ping_interval_can_enable_keepalive_on_a_client_built_without_it() {
+    // The SetVariables path: keepalive was off at construction, and a CSMS turns it on later.
+    let (client, mut pings) = client_with(
+        ClientConfig::new(Duration::from_secs(1)),
+        PongBehavior::Echo,
+    );
+
+    assert!(
+        timeout(Duration::from_millis(200), pings.recv())
+            .await
+            .is_err(),
+        "no pings before it is enabled"
+    );
+
+    client.set_ping_interval(Some(Duration::from_millis(20)));
+
+    timeout(GENEROUS, pings.recv())
+        .await
+        .expect("enabling keepalive at runtime should start pinging")
+        .expect("peer task still running");
+}
+
+#[tokio::test]
+async fn shortening_the_interval_takes_effect_without_waiting_out_the_old_one() {
+    // Starts on an interval far longer than the test's patience; if the loop only re-read the
+    // interval after finishing its current sleep, no ping would arrive for an hour.
+    let config = ClientConfig::new(Duration::from_secs(1)).with_keepalive(
+        KeepaliveBehavior::Enabled(KeepalivePolicy::every(Duration::from_secs(3600))),
+    );
+    let (client, mut pings) = client_with(config, PongBehavior::Echo);
+
+    client.set_ping_interval(Some(Duration::from_millis(20)));
+
+    timeout(GENEROUS, pings.recv())
+        .await
+        .expect("set_ping_interval should wake the keepalive task immediately")
+        .expect("peer task still running");
+}
+
+#[tokio::test]
+async fn disabling_at_runtime_stops_the_pings() {
+    let config = ClientConfig::new(Duration::from_secs(1)).with_keepalive(
+        KeepaliveBehavior::Enabled(KeepalivePolicy::every(Duration::from_millis(20))),
+    );
+    let (client, mut pings) = client_with(config, PongBehavior::Echo);
+
+    timeout(GENEROUS, pings.recv())
+        .await
+        .expect("should be pinging to start with")
+        .expect("peer task still running");
+
+    client.set_ping_interval(None);
+
+    // Drain anything already in flight before the disable landed, then require silence.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    while pings.try_recv().is_ok() {}
+
+    assert!(
+        timeout(Duration::from_millis(300), pings.recv())
+            .await
+            .is_err(),
+        "disabling keepalive should stop the pings"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Dead-peer detection: the point of the whole exercise.
+// ---------------------------------------------------------------------------
+
+/// Hands out a fresh loopback transport on every redial, counting the redials. The peer end of
+/// each new connection answers pings, so the client settles down after reconnecting.
+struct CountingReconnector {
+    calls: Arc<AtomicUsize>,
+    // Kept alive so the reconnected peer task isn't dropped mid-test.
+    keep: Mutex<Vec<tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>>>,
+}
+
+impl Reconnector for CountingReconnector {
+    fn connect<'a>(
+        &'a self,
+    ) -> Pin<
+        Box<
+            dyn Future<
+                    Output = Result<
+                        (Box<dyn TransportSink>, Box<dyn TransportStream>),
+                        TransportError,
+                    >,
+                > + Send
+                + 'a,
+        >,
+    > {
+        Box::pin(async move {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let ((client_sink, client_source), (peer_sink, peer_source)) = fake_transport_pair();
+            let observed = spawn_peer(peer_sink, peer_source, PongBehavior::Echo);
+            self.keep.lock().await.push(observed);
+            Ok((
+                Box::new(client_sink) as Box<dyn TransportSink>,
+                Box::new(client_source) as Box<dyn TransportStream>,
+            ))
+        })
+    }
+}
+
+#[tokio::test]
+async fn a_peer_that_stops_answering_pings_gets_the_connection_redialled() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let ((client_sink, client_source), (peer_sink, peer_source)) = fake_transport_pair();
+    // The initial peer is silent: writes succeed, nothing ever comes back. This is the half-open
+    // connection that `recv` alone can never notice.
+    let _observed = spawn_peer(peer_sink, peer_source, PongBehavior::Silent);
+
+    let config = ClientConfig::new(Duration::from_millis(50))
+        .with_reconnect(
+            Box::new(CountingReconnector {
+                calls: calls.clone(),
+                keep: Mutex::new(Vec::new()),
+            }),
+            ocpp_client::ReconnectPolicy::default(),
+        )
+        .with_keepalive(KeepaliveBehavior::Enabled(KeepalivePolicy {
+            interval: Duration::from_millis(20),
+            timeout: Some(Duration::from_millis(50)),
+            max_missed: 2,
+        }));
+
+    let _client: OCPP1_6Client = Client::from_transport_with_config(
+        Box::new(client_sink),
+        Box::new(client_source),
+        Box::new(TokioExecutor),
+        Box::new(TokioTimer),
+        config,
+    );
+
+    let deadline = tokio::time::Instant::now() + GENEROUS;
+    while calls.load(Ordering::SeqCst) == 0 {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "keepalive should have forced a redial after max_missed unanswered pings"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+#[tokio::test]
+async fn missed_pings_do_not_redial_before_max_missed_is_reached() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let ((client_sink, client_source), (peer_sink, peer_source)) = fake_transport_pair();
+    let _observed = spawn_peer(peer_sink, peer_source, PongBehavior::Silent);
+
+    // One ping every 10s: within the window below, at most one can be missed, and max_missed=5
+    // is far from reached.
+    let config = ClientConfig::new(Duration::from_millis(20))
+        .with_reconnect(
+            Box::new(CountingReconnector {
+                calls: calls.clone(),
+                keep: Mutex::new(Vec::new()),
+            }),
+            ocpp_client::ReconnectPolicy::default(),
+        )
+        .with_keepalive(KeepaliveBehavior::Enabled(KeepalivePolicy {
+            interval: Duration::from_secs(10),
+            timeout: Some(Duration::from_millis(20)),
+            max_missed: 5,
+        }));
+
+    let _client: OCPP1_6Client = Client::from_transport_with_config(
+        Box::new(client_sink),
+        Box::new(client_source),
+        Box::new(TokioExecutor),
+        Box::new(TokioTimer),
+        config,
+    );
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        0,
+        "a single missed ping should be tolerated, not cost a reconnect"
+    );
+}
+
+#[tokio::test]
+async fn force_reconnect_is_inert_without_a_reconnector() {
+    // With nothing to redial with, honoring the signal would just leave the client deaf - worse
+    // than an unanswered ping. So the read loop must keep reading.
+    let ((client_sink, client_source), (peer_sink, peer_source)) = fake_transport_pair();
+    let _observed = spawn_peer(peer_sink, peer_source, PongBehavior::Echo);
+
+    let client: OCPP1_6Client = Client::from_transport(
+        Box::new(client_sink),
+        Box::new(client_source),
+        Duration::from_secs(1),
+        Box::new(TokioExecutor),
+        Box::new(TokioTimer),
+    );
+
+    client.force_reconnect();
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    timeout(GENEROUS, client.send_ping())
+        .await
+        .expect("the read loop should still be running")
+        .expect("and still matching pongs");
+}

--- a/tests/ocpp_1_6_on_reconnect.rs
+++ b/tests/ocpp_1_6_on_reconnect.rs
@@ -72,6 +72,7 @@ async fn on_reconnect_fires_only_after_a_redial() {
             initial_delay: Duration::from_millis(10),
             max_delay: Duration::from_millis(50),
             multiplier: 2,
+            jitter: false,
         },
     );
 

--- a/tests/ocpp_1_6_reconnect.rs
+++ b/tests/ocpp_1_6_reconnect.rs
@@ -57,6 +57,7 @@ async fn client_reconnects_after_the_connection_drops() {
             initial_delay: Duration::from_millis(20),
             max_delay: Duration::from_millis(100),
             multiplier: 2,
+            jitter: false,
         }),
         ..Default::default()
     };

--- a/tests/ocpp_1_6_reconnect_backoff.rs
+++ b/tests/ocpp_1_6_reconnect_backoff.rs
@@ -1,0 +1,271 @@
+//! Reconnect backoff against peers that *accept* the connection and then don't work.
+//!
+//! The bug these pin down: `ReconnectPolicy` only delayed *failed* dials, and the attempt counter
+//! reset on every successful one. A peer that completes the WebSocket handshake and then closes
+//! immediately therefore got redialled with no delay whatsoever, unboundedly - measured at ~9,900
+//! connections in 2 seconds, about 5k/s from a single charge point. Real triggers are ordinary: a
+//! CSMS rejecting the charge point at the application layer, an overloaded endpoint, a load
+//! balancer with no live backend.
+//!
+//! Escalation is now driven by whether a connection carried any inbound traffic, not by whether
+//! the dial completed, and the delay is applied before every dial rather than only after a failure.
+#![allow(clippy::result_large_err)]
+
+use futures::{SinkExt, StreamExt};
+use ocpp_client::{ConnectOptions, ReconnectBehavior, ReconnectPolicy, connect_1_6};
+use ocpp_types::v16::HeartbeatRequest;
+use serde_json::{Value, json};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+use tokio::net::TcpListener;
+use tokio_tungstenite::tungstenite::Message;
+
+type ServerResponse = tokio_tungstenite::tungstenite::handshake::server::Response;
+type ServerRequest = tokio_tungstenite::tungstenite::handshake::server::Request;
+type ServerErrorResponse = tokio_tungstenite::tungstenite::handshake::server::ErrorResponse;
+
+/// Accepts the handshake, picking `ocpp1.6`. Shared by every server in this file.
+fn negotiate_1_6(
+    _req: &ServerRequest,
+    mut response: ServerResponse,
+) -> Result<ServerResponse, ServerErrorResponse> {
+    response
+        .headers_mut()
+        .insert("Sec-WebSocket-Protocol", "ocpp1.6".parse().unwrap());
+    Ok(response)
+}
+
+/// Accepts every connection, completes the WebSocket handshake, then drops it immediately.
+/// Counts how many it got.
+async fn spawn_accept_then_close_server() -> (String, Arc<AtomicUsize>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connections = Arc::new(AtomicUsize::new(0));
+
+    let accepted = connections.clone();
+    tokio::spawn(async move {
+        loop {
+            let Ok((tcp, _)) = listener.accept().await else {
+                break;
+            };
+            accepted.fetch_add(1, Ordering::SeqCst);
+            tokio::spawn(async move {
+                // Handshake, then drop: the dial "succeeds" and the connection is useless.
+                let _ = tokio_tungstenite::accept_hdr_async(tcp, negotiate_1_6).await;
+            });
+        }
+    });
+
+    (format!("ws://{addr}"), connections)
+}
+
+#[tokio::test]
+async fn an_accept_then_close_peer_does_not_get_hammered() {
+    let (address, connections) = spawn_accept_then_close_server().await;
+
+    let options = ConnectOptions {
+        reconnect: ReconnectBehavior::Enabled(ReconnectPolicy {
+            initial_delay: Duration::from_millis(50),
+            max_delay: Duration::from_millis(400),
+            multiplier: 2,
+            jitter: true,
+        }),
+        ..Default::default()
+    };
+    let _client = connect_1_6(&address, Some(options)).await.unwrap();
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    let total = connections.load(Ordering::SeqCst);
+
+    // With 50ms initial delay doubling to a 400ms cap, two seconds allows roughly:
+    // 25 + 50 + 100 + 200 + 200*n ms of waiting, so on the order of ten dials. The old behavior
+    // produced ~9,900. A generous ceiling still separates the two by three orders of magnitude.
+    assert!(
+        total < 40,
+        "expected the backoff to hold the rate down, got {total} connections in 2s"
+    );
+    // And it must not have given up either - a charge point retries its CSMS indefinitely.
+    assert!(
+        total >= 2,
+        "expected it to keep retrying, got only {total} connections"
+    );
+}
+
+#[tokio::test]
+async fn backoff_escalates_across_repeated_useless_connections() {
+    let (address, connections) = spawn_accept_then_close_server().await;
+
+    let options = ConnectOptions {
+        reconnect: ReconnectBehavior::Enabled(ReconnectPolicy {
+            initial_delay: Duration::from_millis(40),
+            max_delay: Duration::from_secs(30),
+            multiplier: 4,
+            jitter: false,
+        }),
+        ..Default::default()
+    };
+    let _client = connect_1_6(&address, Some(options)).await.unwrap();
+
+    // 40ms, then 160ms, then 640ms, then 2560ms... so within a second the delays have grown past
+    // what a non-escalating backoff would ever reach.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    let early = connections.load(Ordering::SeqCst);
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    let late = connections.load(Ordering::SeqCst);
+
+    assert!(
+        late - early <= 2,
+        "the delay should have escalated well past a second, but {} more dials happened in the \
+         following two seconds",
+        late - early
+    );
+}
+
+/// The counterpart guarantee: escalation must not punish a connection that genuinely worked. A
+/// connection that carried traffic resets the backoff, so its later drop is redialled on the
+/// *initial* delay rather than the escalated one.
+///
+/// Measured through `on_reconnect` latency rather than by sending a second request, because a
+/// request issued before the redial completes would just wait out the request timeout and tell us
+/// nothing about the backoff.
+#[tokio::test]
+async fn a_connection_that_carried_traffic_resets_the_backoff() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server = tokio::spawn(async move {
+        // Two accept-then-close connections (plus `connect_1_6`'s own initial dial) push the
+        // backoff up to its third step before anything works.
+        for _ in 0..2 {
+            let (tcp, _) = listener.accept().await.unwrap();
+            let _ = tokio_tungstenite::accept_hdr_async(tcp, negotiate_1_6).await;
+        }
+
+        // A connection that answers a Heartbeat - real inbound traffic - and then drops.
+        let (tcp, _) = listener.accept().await.unwrap();
+        let mut ws = tokio_tungstenite::accept_hdr_async(tcp, negotiate_1_6)
+            .await
+            .unwrap();
+        let frame = match ws.next().await.unwrap().unwrap() {
+            Message::Text(text) => text.to_string(),
+            other => panic!("expected a text frame, got {other:?}"),
+        };
+        let call: Value = serde_json::from_str(&frame).unwrap();
+        let message_id = call[1].as_str().unwrap().to_string();
+        let response = json!([3, message_id, { "currentTime": "2024-01-01T00:00:00Z" }]);
+        ws.send(Message::text(serde_json::to_string(&response).unwrap()))
+            .await
+            .unwrap();
+        ws.close(None).await.unwrap();
+
+        // Keep accepting afterwards so the post-traffic redial has something to reach.
+        loop {
+            let Ok((tcp, _)) = listener.accept().await else {
+                break;
+            };
+            tokio::spawn(async move {
+                if let Ok(mut ws) = tokio_tungstenite::accept_hdr_async(tcp, negotiate_1_6).await {
+                    while let Some(Ok(message)) = ws.next().await {
+                        if matches!(message, Message::Close(_)) {
+                            break;
+                        }
+                    }
+                }
+            });
+        }
+    });
+
+    // multiplier 8 makes the difference unmistakable: reset means the next delay is 30ms, while
+    // continued escalation would put it at 30 * 8^2 = 1920ms.
+    let options = ConnectOptions {
+        reconnect: ReconnectBehavior::Enabled(ReconnectPolicy {
+            initial_delay: Duration::from_millis(30),
+            max_delay: Duration::from_secs(10),
+            multiplier: 8,
+            jitter: false,
+        }),
+        ..Default::default()
+    };
+    let client = connect_1_6(&format!("ws://{addr}"), Some(options))
+        .await
+        .unwrap();
+
+    let (redials_tx, mut redials) = tokio::sync::mpsc::unbounded_channel();
+    client
+        .on_reconnect(move |_| {
+            let tx = redials_tx.clone();
+            async move {
+                let _ = tx.send(tokio::time::Instant::now());
+            }
+        })
+        .await;
+
+    // Let the client climb through the two useless connections and settle on the working one.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let response = tokio::time::timeout(
+        Duration::from_secs(5),
+        client.send_heartbeat(HeartbeatRequest {}),
+    )
+    .await
+    .expect("should have reached the working connection by now")
+    .expect("heartbeat should round-trip");
+    assert_eq!(response.current_time, "2024-01-01T00:00:00Z");
+    let traffic_at = tokio::time::Instant::now();
+
+    // The first redial *after* that traffic is the one whose delay we care about.
+    let redial_at = loop {
+        let at = tokio::time::timeout(Duration::from_secs(5), redials.recv())
+            .await
+            .expect("the dropped connection should be redialled")
+            .expect("on_reconnect sender still alive");
+        if at >= traffic_at {
+            break at;
+        }
+    };
+
+    let gap = redial_at - traffic_at;
+    assert!(
+        gap < Duration::from_millis(800),
+        "a connection that carried traffic should reset the backoff, so the redial should take \
+         about 30ms; it took {gap:?} (escalation would have made it ~1920ms)"
+    );
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn disconnect_during_a_long_backoff_takes_effect_immediately() {
+    let (address, connections) = spawn_accept_then_close_server().await;
+
+    let options = ConnectOptions {
+        reconnect: ReconnectBehavior::Enabled(ReconnectPolicy {
+            // Long enough that a client waiting it out would blow the assertion below.
+            initial_delay: Duration::from_secs(30),
+            max_delay: Duration::from_secs(60),
+            multiplier: 2,
+            jitter: false,
+        }),
+        ..Default::default()
+    };
+    let client = connect_1_6(&address, Some(options)).await.unwrap();
+
+    // Let the initial accept-then-close land, putting the read loop into its 30s backoff.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    let before = connections.load(Ordering::SeqCst);
+
+    tokio::time::timeout(Duration::from_secs(2), client.disconnect())
+        .await
+        .expect("disconnect must not block on the backoff")
+        .unwrap();
+
+    assert!(client.is_closed());
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert_eq!(
+        connections.load(Ordering::SeqCst),
+        before,
+        "no dial should happen after an explicit disconnect"
+    );
+}

--- a/tests/ocpp_1_6_websocket_keepalive.rs
+++ b/tests/ocpp_1_6_websocket_keepalive.rs
@@ -1,0 +1,116 @@
+//! Keepalive over a real WebSocket, not the in-memory fake.
+//!
+//! This exists because the fake transport can't prove the one assumption the whole correlation
+//! scheme rests on: that a real peer echoes a ping's payload back in its pong, per RFC 6455
+//! §5.5.2-3. The fake echoes because it was written to; `tokio-tungstenite`'s server echoes
+//! because the protocol says so. If that ever stopped holding, `send_ping` would time out against
+//! every compliant CSMS and keepalive would redial healthy connections - so it is worth one real
+//! socket to pin down.
+#![allow(clippy::result_large_err)]
+
+use futures::StreamExt;
+use ocpp_client::{ConnectOptions, KeepaliveBehavior, KeepalivePolicy, connect_1_6};
+use std::time::Duration;
+use tokio::net::TcpListener;
+use tokio::time::timeout;
+use tokio_tungstenite::tungstenite::Message;
+
+const GENEROUS: Duration = Duration::from_secs(5);
+
+/// Accepts one OCPP 1.6 connection and then just reads, letting tungstenite handle control
+/// frames the way any real server does - it answers pings automatically, echoing the payload.
+async fn spawn_ocpp_server() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let (tcp, _) = listener.accept().await.unwrap();
+        let mut ws = tokio_tungstenite::accept_hdr_async(
+            tcp,
+            |_req: &tokio_tungstenite::tungstenite::handshake::server::Request,
+             mut response: tokio_tungstenite::tungstenite::handshake::server::Response| {
+                response
+                    .headers_mut()
+                    .insert("Sec-WebSocket-Protocol", "ocpp1.6".parse().unwrap());
+                Ok(response)
+            },
+        )
+        .await
+        .unwrap();
+
+        // Keep polling so tungstenite's automatic pong replies actually get flushed.
+        while let Some(Ok(message)) = ws.next().await {
+            if matches!(message, Message::Close(_)) {
+                break;
+            }
+        }
+    });
+
+    format!("ws://{addr}")
+}
+
+#[tokio::test]
+async fn a_real_server_echoes_the_ping_payload_so_send_ping_resolves() {
+    let address = spawn_ocpp_server().await;
+    let client = connect_1_6(&address, None).await.unwrap();
+
+    timeout(GENEROUS, client.send_ping())
+        .await
+        .expect("send_ping should not hang against a real server")
+        .expect("a compliant server echoes the ping payload, resolving the correlation token");
+}
+
+#[tokio::test]
+async fn scheduled_keepalive_survives_several_intervals_against_a_real_server() {
+    let address = spawn_ocpp_server().await;
+    let options = ConnectOptions {
+        keepalive: KeepaliveBehavior::Enabled(KeepalivePolicy {
+            interval: Duration::from_millis(20),
+            timeout: Some(Duration::from_secs(2)),
+            max_missed: 2,
+        }),
+        ..Default::default()
+    };
+
+    let client = connect_1_6(&address, Some(options)).await.unwrap();
+
+    // Long enough for many intervals to elapse. If pongs weren't being matched, keepalive would
+    // hit max_missed and redial; a redial against this one-shot server leaves the client unable
+    // to complete a ping at all, which the assertion below catches.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    timeout(GENEROUS, client.send_ping())
+        .await
+        .expect("the connection should still be up after many keepalive intervals")
+        .expect("and pings should still be matching");
+}
+
+#[tokio::test]
+async fn connect_options_default_to_keepalive_enabled_at_sixty_seconds() {
+    let address = spawn_ocpp_server().await;
+    let client = connect_1_6(&address, None).await.unwrap();
+
+    assert_eq!(
+        client.ping_interval(),
+        Some(Duration::from_secs(60)),
+        "the WebSocket convenience path should opt into keepalive, and report it for \
+         WebSocketPingInterval"
+    );
+}
+
+#[tokio::test]
+async fn keepalive_can_be_disabled_through_connect_options() {
+    let address = spawn_ocpp_server().await;
+    let options = ConnectOptions {
+        keepalive: KeepaliveBehavior::Disabled,
+        ..Default::default()
+    };
+
+    let client = connect_1_6(&address, Some(options)).await.unwrap();
+
+    assert_eq!(
+        client.ping_interval(),
+        None,
+        "a deployment that forbids unsolicited traffic must be able to turn this off"
+    );
+}


### PR DESCRIPTION
Adds client-initiated WebSocket keepalive — the gap a downstream consumer hit, which forced them to report `OCPPCommCtrlr.WebSocketPingInterval` as a hardcoded `0`. Building it surfaced four pre-existing bugs in the same area, all fixed here because keepalive turns each from theoretical into routine.

## What's in it

**Keepalive.** `KeepalivePolicy`/`KeepaliveBehavior` shaped after the existing reconnect pair; the loop lives in `Client<E>` so any transport gets it. `ConnectOptions` defaults it **on** (60s, tolerating one missed pong); the bare `from_transport*` constructors default it off. `ping_interval()`/`set_ping_interval()` are the non-`async` read/write path for the spec variable, and a write applies immediately rather than after the current interval expires.

**Four bugs fixed**, each with a regression test confirmed to fail against the unfixed code:

| Bug | Impact |
| --- | --- |
| Pongs matched positionally | One timed-out or unsolicited pong desynced every later ping permanently; reachable via reconnect |
| `disconnect()` raced the reconnector | On default options there was **no way to stop a client** — the close looked like a drop and got redialled |
| Backoff reset on every successful dial | A peer that accepts then immediately closes was redialled with no delay: **~9,900 connections in 2 seconds** |
| Three bookkeeping leaks | Every timed-out request leaked a map entry; every handler re-registration leaked a task; `wait_for` silently swallowed later calls |

**`tests/action_coverage.rs`** fails the build if `ocpp-types` defines an action with no macro wrapper — the gap that shipped in 0.2.0 and was invisible at compile time. All three versions are fully covered (28 / 64 / 91).

**Release pipeline** (`.github/workflows/release.yaml`) — a `vX.Y.Z` tag runs the full CI gate (reused via `workflow_call`, not duplicated), verifies tag/manifest/changelog agree and the version isn't already published, then publishes and opens a GitHub Release. Needs a `CARGO_REGISTRY_TOKEN` secret.

## Breaking

- `TransportSink::ping`/`pong` take a `Vec<u8>` payload; `TransportEvent::Ping`/`Pong` carry one.
- `TransportStream::recv` is now contractually **cancel-safe**.
- `ReconnectPolicy` gained `jitter: bool`, breaking struct-literal construction.
- `ConnectOptions::default()` enables keepalive.

The first three affect transport implementors only. Full detail in [CHANGELOG.md](CHANGELOG.md).

## Two behavior changes for existing users

Neither is telegraphed by the version bump alone:

1. **Keepalive is on by default** — unsolicited pings every 60s where there were none. If a CSMS dislikes that, set `KeepaliveBehavior::Disabled`.
2. **The first redial after a drop now waits `initial_delay`** (jittered) instead of firing immediately. Deliberate — instant redial of a just-dropped connection is the pathology — but it's a real change.

## Also

Version → 0.3.0, `rust-version = "1.87"` (verified empirically; the test suite needs 1.88 for dev-deps), a first `CHANGELOG.md`, and `.idea/` excluded from the published crate — it had been shipping inside the tarball through 0.2.2.

README corrected: the transport table advertised "STM32 transport: ✅ Supported" while PRODUCTION_READINESS item 6 — marked *Done* for exactly that overclaim — records that the embedded crates have never run against real hardware or a real CSMS. Only the code half of that item had landed. Also fixed the Quick Example, which called `Client::new()` and `client.connect()`, neither of which exists.

CLAUDE.md rewritten and shortened (256 → 184 lines), leading with the invariants that are easy to break instead of narrative history.

## Verification

Local: fmt, clippy `-D warnings`, 96 tests (was 49), three `no_std` builds, four embedded jobs against real `thumbv7em-none-eabihf`, clean rustdoc, and `cargo publish --dry-run`. CI on this PR is the first time any of it runs on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xu7evjtyZw36tsypRHwDaQ
