### PR TITLE
Migrate to ocpp-types 0.2.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,9 +42,11 @@ jobs:
       - name: Build (default features)
         run: cargo build
       # `--features test` adds the wait_for_* tests (see tests/ocpp_1_6_wait_for.rs) on top of
-      # the default feature set - a plain `cargo test` never runs them.
-      - name: Test (default features + test)
-        run: cargo test --features test
+      # the default feature set - a plain `cargo test` never runs them. `chrono` adds the
+      # interop case in tests/ocpp_1_6_timestamps.rs, which is the only coverage the forwarded
+      # feature has.
+      - name: Test (default features + test + chrono)
+        run: cargo test --features test,chrono
       # Compile-only check for benches/ - catches API breakage in the benchmarks without
       # asserting on timing, which would be flaky on shared CI runners. Run actual benchmarks
       # locally with `cargo bench`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,57 @@ Notable changes per release. Dates are release dates on crates.io.
 This file starts at 0.2.0; earlier releases (0.1.x, a per-version tokio-hardwired design that
 predates the current generic engine) are covered by git history only.
 
+## 0.4.0 - unreleased
+
+Tracks `ocpp-types` 0.2.0. Everything below follows from that release; the engine itself
+(`src/client.rs`, `envelope.rs`, `transport.rs`) needed no changes at all.
+
+### Added
+
+- **The eleven OCPP 1.6 security-whitepaper actions**, which `ocpp-types` 0.2.0 was the first
+  release to define: `CertificateSigned`, `DeleteCertificate`, `ExtendedTriggerMessage`,
+  `GetInstalledCertificateIds`, `GetLog`, `InstallCertificate`, `LogStatusNotification`,
+  `SecurityEventNotification`, `SignCertificate`, `SignedFirmwareStatusNotification` and
+  `SignedUpdateFirmware`. 1.6 now wires up 39 actions rather than 28; 2.0.1 (64) and 2.1 (91) are
+  unchanged. Each gets the usual `send_*`/`on_*`/`wait_for_*` trio, and
+  `tests/ocpp_1_6_security_actions.rs` covers one round trip apiece.
+- **2.x action markers take the `customData` type as a parameter**: `Reset<AcmeExtension>`,
+  `Heartbeat<NoCustomData>`, and so on, defaulting to the specification's `CustomData`. A
+  deployment with a vendor extension richer than a bare `vendorId` can now read and write it
+  through `Client::call`/`Client::on` without hand-writing an `Action` impl. See
+  `tests/custom_data_generics.rs`.
+- **A `chrono` feature**, forwarding to `ocpp-types`' own: `From`/`Into` between `OcppTimestamp`
+  and `chrono::DateTime` for callers that already keep time in chrono. Off by default, and chrono
+  never touches the wire path.
+
+### Changed
+
+- **BREAKING: every `dateTime` field is now `ocpp_types::OcppTimestamp` instead of `String`.**
+  Construct them with `OcppTimestamp::parse_rfc3339(..)` (or `From<chrono::DateTime>` under the
+  new `chrono` feature) and compare against a parsed value rather than a string literal. Beyond
+  the type, this changes behaviour twice over: the client now *validates* what the CSMS sends, so
+  a malformed `dateTime` surfaces as `ClientError::Decode` where it used to be handed through as a
+  string; and the value is an instant, so two timestamps naming the same moment in different UTC
+  offsets compare equal. Fractional seconds and non-UTC offsets both survive the round trip -
+  `tests/ocpp_1_6_timestamps.rs` pins all of it.
+- **BREAKING: 2.0.1 and 2.1 message types carry a `customData` type parameter.** The generated
+  `send_*`/`on_*`/`wait_for_*` methods stay concrete at `CustomData`, so ordinary call sites are
+  unaffected, but a 2.x request or response built in a `let` binding with no expected type now
+  needs an annotation (`let request: ResetRequest = ResetRequest { .. }`) - a defaulted type
+  parameter does not participate in inference. The methods were deliberately left non-generic for
+  exactly this reason; the marker types carry the parameter instead.
+- **BREAKING: `ocpp_types::v16::common::RequestedMessage` is now
+  `TriggerMessageRequestRequestedMessage`**, renamed upstream to make room for
+  `ExtendedTriggerMessageRequestRequestedMessage`. A pure rename, no variants changed.
+- **BREAKING: 48 2.x string fields whose length the specification leaves to a configuration
+  variable are now `String` instead of `heapless::String<N>`** - certificates, certificate
+  chains, CSRs, OCSP results, `MessageContent.content` and the like. Construction drops from
+  `"...".try_into().unwrap()` to `"...".into()`. In the other direction, 89 `dateTime` fields and
+  8 more 2.1 date/time-of-day fields (`TariffConditions.start_time_of_day` and friends) left
+  `String` for `OcppTimestamp`/`OcppDate`/`OcppTimeOfDay`.
+- `ocpp-types` updated to 0.2.0. Its `alloc` feature is now upstream's default; this crate still
+  names its features explicitly, so nothing about the build changes.
+
 ## 0.3.0 - 2026-08-08
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,22 +5,35 @@ Guidance for Claude Code (claude.ai/code) working in this repository.
 ## Project overview
 
 `ocpp-client` implements the **charge point** (client) side of OCPP — the network/protocol layer
-only, not charging logic or hardware control. Current version `0.3.0` (unreleased; 0.2.2 is the
-newest on crates.io). Pre-1.0 and still moving: 0.3.0 alone breaks `TransportSink`/`TransportStream`,
-`ReconnectPolicy`, and `ConnectOptions`' defaults.
+only, not charging logic or hardware control. Current version `0.4.0` (unreleased; 0.3.0 is the
+newest on crates.io). Pre-1.0 and still moving: 0.3.0 broke `TransportSink`/`TransportStream`,
+`ReconnectPolicy` and `ConnectOptions`' defaults, and 0.4.0 breaks every `dateTime` field's type
+and adds a type parameter to the 2.x message types (see below).
 
 **OCPP 1.6, 2.0.1 and 2.1** are all implemented, tested end to end, and in `default` features. Every
-action `ocpp-types` defines is wired up for every version (28 / 64 / 91) — `tests/action_coverage.rs`
-fails the build otherwise. WebSocket is the only production transport; an experimental `embassy-net`
+action `ocpp-types` defines is wired up for every version (39 / 64 / 91) — `tests/action_coverage.rs`
+fails the build otherwise. 1.6's 39 includes the eleven security-whitepaper actions, which arrived
+with `ocpp-types` 0.2.0. WebSocket is the only production transport; an experimental `embassy-net`
 one lives under `crates/` (see the bottom of this file).
 
-Message types come from **`ocpp-types`** (crates.io, `flowionab` org, currently `0.1.3`) — see
-`MIGRATION_OCPP_TYPES.md` for the migration off the old `rust-ocpp` fork. It's `no_std` and
-allocation-free by default; this crate enables its `alloc` feature unconditionally, so
-spec-unbounded fields are plain `String`/`Vec`. Bounded fields (e.g. `IdTag`) stay
-`heapless::String<N>` either way, so construction goes through fallible `TryFrom`. `ocpp-types` has
-no per-version cargo features; this crate's `ocpp_1_6`/`ocpp_2_0_1`/`ocpp_2_1` features only gate its
-own modules.
+Message types come from **`ocpp-types`** (crates.io, `flowionab` org, currently `0.2.0`) — see
+`MIGRATION_OCPP_TYPES.md` for the migration off the old `rust-ocpp` fork and for what 0.2.0
+changed. It's `no_std`, with `alloc` on by default since 0.2.0; this crate enables `alloc`
+unconditionally either way, so spec-unbounded fields are plain `String`/`Vec`. Bounded fields (e.g.
+`IdTag`) stay `heapless::String<N>`, so construction goes through fallible `TryFrom`. Two shapes
+worth knowing before touching a per-version file:
+
+- **`dateTime` fields are `ocpp_types::OcppTimestamp`**, not strings — 16 bytes, comparable, built
+  with `OcppTimestamp::parse_rfc3339`. The client parses them now, so a malformed one from the
+  peer is a `ClientError::Decode`, and equality is by instant, not by written offset.
+  `tests/ocpp_1_6_timestamps.rs` pins that behaviour.
+- **2.0.1/2.1 message types take a `customData` type parameter.** This crate's action markers
+  carry it too (`Reset<AcmeExtension>`), defaulting to the spec's `CustomData`; see
+  `ocpp_2_0_1_action!`'s doc comment for why the generated methods stay concrete.
+
+`ocpp-types` has no per-version cargo features; this crate's `ocpp_1_6`/`ocpp_2_0_1`/`ocpp_2_1`
+features only gate its own modules. The optional `chrono` feature forwards to `ocpp-types`' own,
+adding `OcppTimestamp` ↔ `chrono::DateTime` conversions and nothing else.
 
 ## Architecture
 
@@ -114,7 +127,9 @@ These each cost a real bug once. Read them before touching `client.rs`.
 ### Adding an action
 
 Add one `ocpp_{1_6,2_0_1,2_1}_action!(...)` line in that version's `actions.rs` with the
-`ocpp_types::{v16,v201,v21}` request/response types. **Write the test first.** Nested enum/field
+`ocpp_types::{v16,v201,v21}` request/response types. **Write the test first.** The 2.x macros take
+the request/response as `ident`s, not `ty`s, because they append the `customData` parameter to
+them — pass the bare type name and nothing else. Nested enum/field
 types live under that version's `common` submodule, not the version root. The action name string is
 the struct name minus its `Request`/`Response` suffix; method names are its snake_case (existing
 invocations are the reference for acronym runs — `Get15118EVCertificate` →
@@ -135,16 +150,24 @@ Every behavior has a test in `tests/`. Two styles, mirrored per version:
 Tests needing the `test` feature (`wait_for_*`, bookkeeping) are invisible to a plain `cargo test`;
 run `cargo test --features test`.
 
-Three suites don't fit either style and aren't mirrored per version:
+Some suites don't fit either style and aren't mirrored per version:
 - `tests/action_coverage.rs` — locates the `ocpp-types` source via `cargo metadata`, reads the
   `const ACTION` from each `*_request.rs`, and fails if any action lacks a macro invocation. Guards
-  the gap that shipped in 0.2.0 (five actions with types present but no wrapper). If `ocpp-types`
-  changes its one-file-per-type layout, this is what breaks.
+  the gap that shipped in 0.2.0 (five actions with types present but no wrapper), and is what
+  caught the eleven 1.6 security actions arriving in `ocpp-types` 0.2.0. If `ocpp-types` changes
+  its one-file-per-type layout, this is what breaks.
 - `tests/ocpp_1_6_keepalive.rs` / `_websocket_keepalive.rs` — ping/pong and scheduled keepalive.
   Version-independent, so 1.6 only. Millisecond intervals with generous `timeout(..)` bounds rather
   than a mock clock; the real-socket file exists to prove a real peer echoes ping payloads.
 - `tests/ocpp_1_6_bookkeeping.rs` / `_disconnect.rs` / `_reconnect_backoff.rs` — the invariants
   above. Each case was confirmed to fail against the unfixed code; keep that property.
+- `tests/ocpp_1_6_timestamps.rs` — what a peer may write in a `dateTime` field and what happens
+  when it writes nonsense. Version-independent (the type is shared), so 1.6 only. The `chrono`
+  case is `#[cfg(feature = "chrono")]`, so it needs `cargo test --features test,chrono`.
+- `tests/custom_data_generics.rs` — the 2.x `customData` type parameter, through both `call` and
+  `on`, including that the marker's default keeps the spec shape rather than `NoCustomData`.
+- `tests/ocpp_1_6_security_actions.rs` — one round trip per security-whitepaper action, split by
+  who initiates it. `action_coverage` proves the wiring exists; this proves it works.
 
 ## Common commands
 
@@ -157,18 +180,19 @@ satellite crates under `crates/` need an explicit `-p`. Don't use `--workspace` 
 ```sh
 cargo build                                   # default: std, tokio-runtime, websocket, all three versions
 cargo test --features test                    # all tests, including the test-gated ones
+cargo test --features test,chrono             # adds the chrono-interop case in tests/ocpp_1_6_timestamps.rs
 cargo test <name>                             # single test, substring match
 cargo fmt                                     # rustfmt, per CONTRIBUTING.md
 cargo build --no-default-features --features std,ocpp_1_6      # core + 1.6, no tokio/WebSocket
 cargo build --lib --no-default-features --features ocpp_1_6    # no_std+alloc proof (lib-only, no --target needed)
 ```
 
-MSRV is **1.87** for the library (bound by `heapless` via `ocpp-types`); the test suite needs 1.88
-for dev-dependencies. Verify with `cargo +1.87 check --lib --all-features`.
+MSRV is **1.87** for the library (`ocpp-types` declares the same, and is what binds it); the test
+suite needs 1.88 for dev-dependencies. Verify with `cargo +1.87 check --lib --all-features`.
 
 CI (`.github/workflows/ci.yaml`) runs five jobs on push-to-`main` and every PR: `fmt`, `clippy`
 (`--all-targets --all-features -D warnings`), `test` (`cargo build` then
-`cargo test --features test`), `no_std` (the three lib-only proof builds), and `embedded`
+`cargo test --features test,chrono`), `no_std` (the three lib-only proof builds), and `embedded`
 (checks/clippies `ocpp-transport-embassy-net` and full-links `ocpp-board-stm32h723-nucleo` against
 the real `thumbv7em-none-eabihf` target, with `RUSTFLAGS: --cfg getrandom_backend="custom"`). Keep
 all five green — the `embedded` job in particular catches dead code that host builds don't.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ default-members = ["."]
 [package]
 edition = '2024'
 name = "ocpp-client"
-version = "0.3.0"
+version = "0.4.0"
 description = "OCPP Client Implementation. Use this library to implement an OCPP charge point"
 repository = "https://github.com/flowionab/ocpp-client"
 documentation = "https://docs.rs/ocpp-client"
@@ -32,8 +32,8 @@ authors = ["Joatin Granlund <joatin@granlund.io>"]
 keywords = ["ocpp", "charge-point", "ocpp16", "ocpp201", "ocpp21"]
 categories = ["network-programming", "embedded", "no-std"]
 # What a *consumer* needs to build the library. Verified empirically with
-# `cargo +1.87 check --lib --all-features`; the binding constraint is `heapless` 0.9 (via
-# ocpp-types), not this crate's own code. Building the test suite needs 1.88 - the `rcgen`/`time`
+# `cargo +1.87 check --lib --all-features`; the binding constraint is `ocpp-types`, which declares
+# the same 1.87, not this crate's own code. Building the test suite needs 1.88 - the `rcgen`/`time`
 # dev-dependencies and a let-chain in tests/ - but that only affects contributors, not users.
 rust-version = "1.87"
 # Keep editor and CI scaffolding out of the published tarball. `.idea/` was shipping inside the
@@ -54,7 +54,10 @@ default = ["std", "tokio-runtime", "websocket", "ocpp_1_6", "ocpp_2_0_1", "ocpp_
 # global-only dispatch). `ocpp-types` needs no forwarding here - its own `alloc` feature is
 # unconditionally enabled below regardless of this crate's `std` status, since even the
 # no_std+alloc build wants plain `alloc::String`/`Vec` for spec-unbounded fields rather than
-# const-generic-sized `heapless` collections (see MIGRATION_OCPP_TYPES.md). Disable `std` for
+# const-generic-sized `heapless` collections (see MIGRATION_OCPP_TYPES.md). That choice is also
+# what keeps the message types free of const-generic capacity parameters: `ocpp-types` only
+# declares those in its allocation-free shape, so the sole type parameter a consumer of this
+# crate ever sees is 2.x's `customData` one. Disable `std` for
 # no_std + alloc targets (embedded); the engine itself (src/client.rs) has no unconditional
 # std/tokio dependency left - see the `Executor`/`Timer` traits in src/runtime.rs. Embedded
 # users must supply their own `Executor`/`Timer` impls plus a `critical-section` backend for
@@ -71,12 +74,20 @@ websocket = ["tokio-runtime", "dep:tokio-tungstenite", "dep:futures", "dep:url",
 ocpp_1_6 = []
 ocpp_2_0_1 = []
 ocpp_2_1 = []
+# `From`/`Into` between `ocpp_types::OcppTimestamp` - the type every version's `dateTime` fields
+# use since ocpp-types 0.2.0 - and `chrono::DateTime`. Purely additive interop for consumers that
+# already keep time in chrono; nothing in this crate needs it, and chrono never reaches the wire
+# path (its serde support allocates, which the allocation-free build cannot use).
+chrono = ["ocpp-types/chrono"]
 test = []
 
 [dependencies]
-# Strongly typed, no_std+no_alloc-by-default OCPP message types generated from the official
-# JSON schemas - see MIGRATION_OCPP_TYPES.md for why this replaced the rust-ocpp fork.
-ocpp-types = { version = "0.1.3", default-features = false, features = ["serde", "alloc"] }
+# Strongly typed `no_std` OCPP message types generated from the official JSON schemas - see
+# MIGRATION_OCPP_TYPES.md for why this replaced the rust-ocpp fork, and its 0.2.0 section for what
+# that release changed. `default-features = false` is deliberate even though `alloc` is now
+# upstream's default: the features this crate needs are named explicitly so a future default
+# gaining something else doesn't pull it in silently.
+ocpp-types = { version = "0.2.0", default-features = false, features = ["serde", "alloc"] }
 serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = "1", default-features = false, features = ["alloc"] }
 uuid = { version = "1", default-features = false, features = ["v4"] }

--- a/MIGRATION_OCPP_TYPES.md
+++ b/MIGRATION_OCPP_TYPES.md
@@ -153,3 +153,73 @@ depends on for `rust-ocpp`. Worth re-running the same kind of schema-vs-generate
 (see step 2's collision-detection script, not checked into this repo) before trusting 2.0.1/2.1
 blindly in step 3-4, even though the structural reason for the 1.6 bug (anonymous inline enums)
 doesn't apply to their `$ref`-based schemas.
+
+---
+
+# `ocpp-types` 0.1.3 → 0.2.0 (this crate's 0.4.0)
+
+A second migration, on the same dependency. Four upstream changes, none of which touched the
+engine - `client.rs`, `envelope.rs`, `transport.rs`, `error.rs`, `runtime.rs` and `sync.rs` all
+compiled against 0.2.0 with no edits at all, which is the same result 2.0.1 and 2.1 gave when they
+were ported.
+
+1. **`dateTime` fields became `OcppTimestamp`.** Upstream's reason is size: not one of the 142
+   `dateTime` fields across the three versions declares a `maxLength`, so as unbounded strings
+   they each reserved the generator's 1024-byte default (`v16::HeartbeatResponse` was 1,032 bytes
+   to carry a 24-character instant). The type is 16 bytes, allocator-free and comparable.
+
+   For this crate the consequence is behavioural, not just structural: timestamps are *parsed*
+   now, so a `dateTime` the CSMS writes badly fails the call as `ClientError::Decode` rather than
+   reaching the caller as a bad string, and two timestamps naming the same instant in different
+   UTC offsets compare equal. Fractional seconds (any precision) and non-UTC offsets survive a
+   round trip. All of it is pinned by `tests/ocpp_1_6_timestamps.rs`. Everything else was
+   mechanical: ~30 sites in `tests/`, `benches/` and `examples/` moved from string literals to
+   `OcppTimestamp::parse_rfc3339(..)`.
+
+2. **2.0.1/2.1 message types gained a `customData` type parameter**, defaulting upstream to the
+   new zero-sized `NoCustomData` (which accepts a `customData` object and discards it). Taking
+   that default unchanged would have silently downgraded every 2.x caller's `custom_data`, so the
+   action markers this crate generates carry the parameter themselves -
+   `pub struct Reset<C = CustomData>(PhantomData<fn() -> C>)` - defaulting to the specification's
+   own shape. A deployment with a richer vendor extension names its own type
+   (`client.call::<Reset<AcmeExtension>>(..)`), which was previously only possible by
+   hand-writing an `Action` impl.
+
+   The generated `send_*`/`on_*`/`wait_for_*` methods were deliberately **not** made generic. A
+   generic method breaks inference at every call site that builds a request inline with
+   `custom_data: None` - a defaulted type parameter does not participate in inference - which
+   would have put a turbofish on the common path to serve the rare one. The same inference rule
+   is why a handful of test-side literals now need `let request: ResetRequest = ..`.
+
+   Two mechanical consequences inside the macros: `$req`/`$res` had to become `ident` fragments,
+   since a `ty` fragment cannot be followed by generic arguments; and the marker holds
+   `PhantomData<fn() -> C>` rather than `PhantomData<C>` so it stays `Send + Sync` - which
+   `Action` requires of the marker itself - whatever `C` is.
+
+3. **Eleven new OCPP 1.6 security-whitepaper actions.** `tests/action_coverage.rs` failed the
+   moment the dependency was bumped, listing exactly those eleven, which is what that test was
+   built for. One `ocpp_1_6_action!` line each, plus `tests/ocpp_1_6_security_actions.rs`
+   covering a round trip apiece (`send_*` for the four a charge point initiates, `on_*` for the
+   seven a CSMS initiates). 1.6 went 28 → 39; 2.0.1 and 2.1 were unchanged.
+
+4. **Additive extras.** `alloc` is now upstream's default feature (this crate names its features
+   explicitly, so nothing changed); a new `chrono` feature adds `OcppTimestamp` ↔
+   `chrono::DateTime` conversions, forwarded through this crate's own `chrono` feature; and each
+   version gained a `standard` module of value-set enums for fields the schemas type as bare
+   strings (`SecurityEventNotification.type`, `Variable.name`, 1.6's configuration keys). The
+   `standard` modules need no wiring - they are reachable as
+   `ocpp_client::ocpp_types::v16::standard::*`.
+
+Two smaller shifts show up when reading old code. `v16::common::RequestedMessage` is now
+`TriggerMessageRequestRequestedMessage`, to make room for the `ExtendedTriggerMessage` variant of
+the same idea (variants unchanged). And 48 2.x fields whose length the specification delegates to
+a configuration variable - certificates, chains, CSRs, OCSP results, `MessageContent.content` -
+moved from `heapless::String<N>` to `String`, so their construction drops from
+`try_into().unwrap()` to `into()`. Only one site in this repo was affected, and clippy's
+`unnecessary_fallible_conversions` found it; the compiler catches the reverse direction.
+
+Upstream's remaining `0.2.0` headline - per-field const-generic capacities, and the sizing table
+in its crate docs - does not reach consumers of this crate: those parameters only exist in
+`ocpp-types`' allocation-free shape, and this crate enables `alloc` unconditionally. If that ever
+changes, every message type acquires a second family of parameters and the macros will need the
+same treatment `customData` just got.

--- a/PRODUCTION_READINESS.md
+++ b/PRODUCTION_READINESS.md
@@ -67,17 +67,20 @@ per-crate READMEs are specifically about the **embedded** satellite crates
    and `::on_notify_periodic_event_stream_fires_and_never_sends_a_reply`, the latter also
    asserting the client never auto-replies to a received SEND.
 
-5. **Versioning/release.** Crate is `0.3.0` (unreleased; 0.2.2 is the newest on crates.io). The
-   git-fork dependency blocker is long gone - `ocpp-types` is a real crates.io release (`0.1.3`),
-   not a git dependency. `ocpp-types` itself is still early (`0.1.x`, same org as the old
+5. **Versioning/release.** Crate is `0.4.0` (unreleased; 0.3.0 is the newest on crates.io). The
+   git-fork dependency blocker is long gone - `ocpp-types` is a real crates.io release (`0.2.0`),
+   not a git dependency. `ocpp-types` itself is still early (`0.2.x`, same org as the old
    `rust-ocpp` fork - see `MIGRATION_OCPP_TYPES.md`'s Risk section for a codegen bug found and
-   fixed upstream mid-migration), so pin it deliberately rather than assuming API stability. This
-   crate's own API is pre-1.0 and still moving: 0.3.0 alone carries breaking changes to
-   `TransportSink`/`TransportStream`, `ReconnectPolicy`, and `ConnectOptions`' defaults.
+   fixed upstream mid-migration), so pin it deliberately rather than assuming API stability - its
+   0.2.0 was itself a breaking release, and the section at the bottom of that file records what it
+   cost here. This crate's own API is pre-1.0 and still moving: 0.3.0 carried breaking changes to
+   `TransportSink`/`TransportStream`, `ReconnectPolicy` and `ConnectOptions`' defaults, and 0.4.0
+   changes every `dateTime` field's type and adds a `customData` type parameter to the 2.x
+   markers.
 
    Release metadata was tidied at the same time: `rust-version = "1.87"` (verified with
-   `cargo +1.87 check --lib --all-features`; the binding constraint is `heapless` 0.9 via
-   `ocpp-types`, and building the *test suite* needs 1.88 for dev-dependencies), plus
+   `cargo +1.87 check --lib --all-features`; the binding constraint is `ocpp-types`, which
+   declares the same 1.87, and building the *test suite* needs 1.88 for dev-dependencies), plus
    `categories`, `readme`, `documentation`, a `keywords` list that finally mentions 2.1, and an
    `exclude` that keeps `.idea/`/`.github/` out of the published tarball - `.idea/` had been
    shipping inside the crate through 0.2.2, and was also purged from git history.

--- a/README.md
+++ b/README.md
@@ -54,9 +54,12 @@ The library currently supports **OCPP 1.6J**, **OCPP 2.0.1**, and **OCPP 2.1**.
 
 | Protocol   | Status         | Actions wired up |
 | ---------- | -------------- | ---------------- |
-| OCPP 1.6J  | ✅ Supported    | all 28           |
+| OCPP 1.6J  | ✅ Supported    | all 39           |
 | OCPP 2.0.1 | ✅ Supported    | all 64           |
 | OCPP 2.1   | ✅ Supported    | all 91           |
+
+1.6's 39 includes the eleven actions from the security whitepaper (`SignCertificate`, `GetLog`,
+`SignedUpdateFirmware` and friends), wired up in **0.4.0** when `ocpp-types` first defined them.
 
 Every action defined by [`ocpp-types`](https://crates.io/crates/ocpp-types) for each version has a
 `send_*`/`on_*` method - `tests/action_coverage.rs` fails the build otherwise, so the table can't
@@ -102,6 +105,8 @@ ocpp-client = { version = "0.x", default-features = false }
 ```
 
 This lets the same OCPP communication core compile for resource-constrained devices as well as server-side applications. Embedded users supply their own `Executor`/`Timer` implementations (e.g. backed by `embassy-executor`/`embassy-time`) and a `critical-section` backend for their target.
+
+The optional `chrono` feature adds `From`/`Into` between `ocpp_types::OcppTimestamp` - the type every `dateTime` field uses - and `chrono::DateTime`, for applications that already keep time in chrono. It is interop only; chrono never reaches the wire.
 
 ---
 
@@ -264,6 +269,27 @@ async fn main() {
 
 Use `connect_2_0_1`/`connect_2_1` for those versions, or `connect` to negotiate whichever version
 the server picks.
+
+### Vendor extensions (`customData`)
+
+2.0.1 and 2.1 hang an optional `customData` object on nearly every message. The `send_*`/`on_*`
+methods use the specification's own shape - a bare `vendorId` - which is all most deployments
+need. To carry your own, name the type on the action marker and go through `call`/`on`:
+
+```rust,ignore
+#[derive(serde::Serialize, serde::Deserialize)]
+struct AcmeExtension {
+    #[serde(rename = "vendorId")]
+    vendor_id: String,
+    #[serde(rename = "siteId")]
+    site_id: u32,
+}
+
+let response = client.call::<Reset<AcmeExtension>>(request).await?;
+```
+
+`NoCustomData` is the other end of the trade: it accepts whatever a peer sends and discards it,
+costing one byte per node instead of the field's full width - worth naming on an MCU.
 
 ---
 

--- a/benches/call_roundtrip.rs
+++ b/benches/call_roundtrip.rs
@@ -8,6 +8,7 @@ use ocpp_client::{
     Client, TokioExecutor, TokioTimer, TransportError, TransportEvent, TransportSink,
     TransportStream,
 };
+use ocpp_types::OcppTimestamp;
 use ocpp_types::v16::{HeartbeatRequest, HeartbeatResponse};
 use serde_json::{Value, json};
 use std::future::Future;
@@ -103,7 +104,7 @@ fn bench_heartbeat_roundtrip(c: &mut Criterion) {
             let message_id = frame[1].as_str().unwrap().to_string();
 
             let response = HeartbeatResponse {
-                current_time: "2026-08-06T00:00:00Z".to_string(),
+                current_time: OcppTimestamp::parse_rfc3339("2026-08-06T00:00:00Z").unwrap(),
             };
             let result_frame = serde_json::to_string(&json!([3, message_id, response])).unwrap();
             peer_sink.send(result_frame).await.unwrap();
@@ -128,7 +129,7 @@ fn bench_envelope_serde(c: &mut Criterion) {
                 3,
                 "abc-123",
                 HeartbeatResponse {
-                    current_time: "2026-08-06T00:00:00Z".to_string(),
+                    current_time: OcppTimestamp::parse_rfc3339("2026-08-06T00:00:00Z").unwrap(),
                 }
             ])
             .to_string()

--- a/src/ocpp_1_6/actions.rs
+++ b/src/ocpp_1_6/actions.rs
@@ -5,23 +5,31 @@ use crate::ocpp_1_6::error::OCPP1_6Error;
 use core::future::Future;
 use ocpp_types::v16::{
     AuthorizeRequest, AuthorizeResponse, BootNotificationRequest, BootNotificationResponse,
-    CancelReservationRequest, CancelReservationResponse, ChangeAvailabilityRequest,
-    ChangeAvailabilityResponse, ChangeConfigurationRequest, ChangeConfigurationResponse,
-    ClearCacheRequest, ClearCacheResponse, ClearChargingProfileRequest,
-    ClearChargingProfileResponse, DataTransferRequest, DataTransferResponse,
+    CancelReservationRequest, CancelReservationResponse, CertificateSignedRequest,
+    CertificateSignedResponse, ChangeAvailabilityRequest, ChangeAvailabilityResponse,
+    ChangeConfigurationRequest, ChangeConfigurationResponse, ClearCacheRequest, ClearCacheResponse,
+    ClearChargingProfileRequest, ClearChargingProfileResponse, DataTransferRequest,
+    DataTransferResponse, DeleteCertificateRequest, DeleteCertificateResponse,
     DiagnosticsStatusNotificationRequest, DiagnosticsStatusNotificationResponse,
+    ExtendedTriggerMessageRequest, ExtendedTriggerMessageResponse,
     FirmwareStatusNotificationRequest, FirmwareStatusNotificationResponse,
     GetCompositeScheduleRequest, GetCompositeScheduleResponse, GetConfigurationRequest,
     GetConfigurationResponse, GetDiagnosticsRequest, GetDiagnosticsResponse,
-    GetLocalListVersionRequest, GetLocalListVersionResponse, HeartbeatRequest, HeartbeatResponse,
-    MeterValuesRequest, MeterValuesResponse, RemoteStartTransactionRequest,
-    RemoteStartTransactionResponse, RemoteStopTransactionRequest, RemoteStopTransactionResponse,
-    ReserveNowRequest, ReserveNowResponse, ResetRequest, ResetResponse, SendLocalListRequest,
-    SendLocalListResponse, SetChargingProfileRequest, SetChargingProfileResponse,
-    StartTransactionRequest, StartTransactionResponse, StatusNotificationRequest,
-    StatusNotificationResponse, StopTransactionRequest, StopTransactionResponse,
-    TriggerMessageRequest, TriggerMessageResponse, UnlockConnectorRequest, UnlockConnectorResponse,
-    UpdateFirmwareRequest, UpdateFirmwareResponse,
+    GetInstalledCertificateIdsRequest, GetInstalledCertificateIdsResponse,
+    GetLocalListVersionRequest, GetLocalListVersionResponse, GetLogRequest, GetLogResponse,
+    HeartbeatRequest, HeartbeatResponse, InstallCertificateRequest, InstallCertificateResponse,
+    LogStatusNotificationRequest, LogStatusNotificationResponse, MeterValuesRequest,
+    MeterValuesResponse, RemoteStartTransactionRequest, RemoteStartTransactionResponse,
+    RemoteStopTransactionRequest, RemoteStopTransactionResponse, ReserveNowRequest,
+    ReserveNowResponse, ResetRequest, ResetResponse, SecurityEventNotificationRequest,
+    SecurityEventNotificationResponse, SendLocalListRequest, SendLocalListResponse,
+    SetChargingProfileRequest, SetChargingProfileResponse, SignCertificateRequest,
+    SignCertificateResponse, SignedFirmwareStatusNotificationRequest,
+    SignedFirmwareStatusNotificationResponse, SignedUpdateFirmwareRequest,
+    SignedUpdateFirmwareResponse, StartTransactionRequest, StartTransactionResponse,
+    StatusNotificationRequest, StatusNotificationResponse, StopTransactionRequest,
+    StopTransactionResponse, TriggerMessageRequest, TriggerMessageResponse, UnlockConnectorRequest,
+    UnlockConnectorResponse, UpdateFirmwareRequest, UpdateFirmwareResponse,
 };
 
 /// Declares one OCPP 1.6 action: a zero-sized marker type implementing [`Action`], plus
@@ -95,6 +103,15 @@ ocpp_1_6_action!(
     wait_for_cancel_reservation
 );
 ocpp_1_6_action!(
+    CertificateSigned,
+    CertificateSignedRequest,
+    CertificateSignedResponse,
+    "CertificateSigned",
+    send_certificate_signed,
+    on_certificate_signed,
+    wait_for_certificate_signed
+);
+ocpp_1_6_action!(
     ChangeAvailability,
     ChangeAvailabilityRequest,
     ChangeAvailabilityResponse,
@@ -140,6 +157,15 @@ ocpp_1_6_action!(
     wait_for_data_transfer
 );
 ocpp_1_6_action!(
+    DeleteCertificate,
+    DeleteCertificateRequest,
+    DeleteCertificateResponse,
+    "DeleteCertificate",
+    send_delete_certificate,
+    on_delete_certificate,
+    wait_for_delete_certificate
+);
+ocpp_1_6_action!(
     DiagnosticsStatusNotification,
     DiagnosticsStatusNotificationRequest,
     DiagnosticsStatusNotificationResponse,
@@ -147,6 +173,15 @@ ocpp_1_6_action!(
     send_diagnostics_status_notification,
     on_diagnostics_status_notification,
     wait_for_diagnostics_status_notification
+);
+ocpp_1_6_action!(
+    ExtendedTriggerMessage,
+    ExtendedTriggerMessageRequest,
+    ExtendedTriggerMessageResponse,
+    "ExtendedTriggerMessage",
+    send_extended_trigger_message,
+    on_extended_trigger_message,
+    wait_for_extended_trigger_message
 );
 ocpp_1_6_action!(
     FirmwareStatusNotification,
@@ -185,6 +220,15 @@ ocpp_1_6_action!(
     wait_for_get_diagnostics
 );
 ocpp_1_6_action!(
+    GetInstalledCertificateIds,
+    GetInstalledCertificateIdsRequest,
+    GetInstalledCertificateIdsResponse,
+    "GetInstalledCertificateIds",
+    send_get_installed_certificate_ids,
+    on_get_installed_certificate_ids,
+    wait_for_get_installed_certificate_ids
+);
+ocpp_1_6_action!(
     GetLocalListVersion,
     GetLocalListVersionRequest,
     GetLocalListVersionResponse,
@@ -194,6 +238,15 @@ ocpp_1_6_action!(
     wait_for_get_local_list_version
 );
 ocpp_1_6_action!(
+    GetLog,
+    GetLogRequest,
+    GetLogResponse,
+    "GetLog",
+    send_get_log,
+    on_get_log,
+    wait_for_get_log
+);
+ocpp_1_6_action!(
     Heartbeat,
     HeartbeatRequest,
     HeartbeatResponse,
@@ -201,6 +254,24 @@ ocpp_1_6_action!(
     send_heartbeat,
     on_heartbeat,
     wait_for_heartbeat
+);
+ocpp_1_6_action!(
+    InstallCertificate,
+    InstallCertificateRequest,
+    InstallCertificateResponse,
+    "InstallCertificate",
+    send_install_certificate,
+    on_install_certificate,
+    wait_for_install_certificate
+);
+ocpp_1_6_action!(
+    LogStatusNotification,
+    LogStatusNotificationRequest,
+    LogStatusNotificationResponse,
+    "LogStatusNotification",
+    send_log_status_notification,
+    on_log_status_notification,
+    wait_for_log_status_notification
 );
 ocpp_1_6_action!(
     MeterValues,
@@ -248,6 +319,15 @@ ocpp_1_6_action!(
     wait_for_reset
 );
 ocpp_1_6_action!(
+    SecurityEventNotification,
+    SecurityEventNotificationRequest,
+    SecurityEventNotificationResponse,
+    "SecurityEventNotification",
+    send_security_event_notification,
+    on_security_event_notification,
+    wait_for_security_event_notification
+);
+ocpp_1_6_action!(
     SendLocalList,
     SendLocalListRequest,
     SendLocalListResponse,
@@ -264,6 +344,33 @@ ocpp_1_6_action!(
     send_set_charging_profile,
     on_set_charging_profile,
     wait_for_set_charging_profile
+);
+ocpp_1_6_action!(
+    SignCertificate,
+    SignCertificateRequest,
+    SignCertificateResponse,
+    "SignCertificate",
+    send_sign_certificate,
+    on_sign_certificate,
+    wait_for_sign_certificate
+);
+ocpp_1_6_action!(
+    SignedFirmwareStatusNotification,
+    SignedFirmwareStatusNotificationRequest,
+    SignedFirmwareStatusNotificationResponse,
+    "SignedFirmwareStatusNotification",
+    send_signed_firmware_status_notification,
+    on_signed_firmware_status_notification,
+    wait_for_signed_firmware_status_notification
+);
+ocpp_1_6_action!(
+    SignedUpdateFirmware,
+    SignedUpdateFirmwareRequest,
+    SignedUpdateFirmwareResponse,
+    "SignedUpdateFirmware",
+    send_signed_update_firmware,
+    on_signed_update_firmware,
+    wait_for_signed_update_firmware
 );
 ocpp_1_6_action!(
     StartTransaction,

--- a/src/ocpp_2_0_1/actions.rs
+++ b/src/ocpp_2_0_1/actions.rs
@@ -3,6 +3,8 @@ use crate::error::ClientError;
 use crate::ocpp_2_0_1::OCPP2_0_1Client;
 use crate::ocpp_2_0_1::error::OCPP2_0_1Error;
 use core::future::Future;
+use core::marker::PhantomData;
+use ocpp_types::v201::common::CustomData;
 use ocpp_types::v201::{
     AuthorizeRequest, AuthorizeResponse, BootNotificationRequest, BootNotificationResponse,
     CancelReservationRequest, CancelReservationResponse, CertificateSignedRequest,
@@ -47,30 +49,60 @@ use ocpp_types::v201::{
     UnlockConnectorRequest, UnlockConnectorResponse, UnpublishFirmwareRequest,
     UnpublishFirmwareResponse, UpdateFirmwareRequest, UpdateFirmwareResponse,
 };
+use serde::Serialize;
+use serde::de::DeserializeOwned;
 
 /// Same pattern as `ocpp_1_6_action!` (see `src/ocpp_1_6/actions.rs`): one marker type
 /// implementing [`Action`] plus `send_x`/`on_x`/`wait_for_x` convenience methods on
 /// [`OCPP2_0_1Client`], generated from one macro line per action.
+///
+/// The one thing 2.x adds is the `customData` extension point. Since `ocpp-types` 0.2.0 every
+/// 2.0.1 message type carries the type of that field as a parameter, so the marker carries it
+/// too and a consumer picks their own shape with `client.call::<Reset<AcmeExtension>>(..)`. The
+/// methods stay concrete at [`CustomData`], the specification's own shape: making them generic
+/// as well would break inference at the call site every time a request is built inline with
+/// `custom_data: None`, since a defaulted type parameter does not participate in inference.
+///
+/// `$req`/`$res` are `ident`s rather than `ty`s because a `ty` fragment cannot be followed by
+/// generic arguments.
 macro_rules! ocpp_2_0_1_action {
-    ($name:ident, $req:ty, $res:ty, $action:literal, $send:ident, $on:ident, $wait_for:ident) => {
+    ($name:ident, $req:ident, $res:ident, $action:literal, $send:ident, $on:ident, $wait_for:ident) => {
         #[doc = concat!("Marker type for the `", $action, "` action.")]
-        pub struct $name;
+        ///
+        /// `C` is the type of the message's `customData` field, defaulting to the
+        /// specification's [`CustomData`]. Name another to read or write a vendor extension
+        /// through [`Client::call`](crate::Client::call)/[`Client::on`](crate::Client::on), or
+        /// [`NoCustomData`](ocpp_types::NoCustomData) to discard it and pay one byte instead of
+        /// the field's full width at every node of the message.
+        pub struct $name<C = CustomData>(PhantomData<fn() -> C>);
 
-        impl Action for $name {
+        // `fn() -> C` rather than a bare `C`: the marker is a type-level tag that is never
+        // instantiated, and this keeps it `Send + Sync` (which `Action` requires of the marker
+        // itself) no matter what `C` is.
+        impl<C> Action for $name<C>
+        where
+            C: Serialize + DeserializeOwned + Send + Sync + 'static,
+        {
             const NAME: &'static str = $action;
-            type Request = $req;
-            type Response = $res;
+            type Request = $req<C>;
+            type Response = $res<C>;
         }
 
         impl OCPP2_0_1Client {
-            pub async fn $send(&self, request: $req) -> Result<$res, ClientError<OCPP2_0_1Error>> {
+            // `$req<CustomData>` spelled out, not bare `$req`: `ocpp-types`' own default for the
+            // parameter is `NoCustomData`, which would silently discard vendor extensions. The
+            // marker's default is this crate's choice and matches.
+            pub async fn $send(
+                &self,
+                request: $req<CustomData>,
+            ) -> Result<$res<CustomData>, ClientError<OCPP2_0_1Error>> {
                 self.call::<$name>(request).await
             }
 
             pub async fn $on<F, FF>(&self, callback: F)
             where
-                F: FnMut($req, Self) -> FF + Send + Sync + 'static,
-                FF: Future<Output = Result<$res, OCPP2_0_1Error>> + Send,
+                F: FnMut($req<CustomData>, Self) -> FF + Send + Sync + 'static,
+                FF: Future<Output = Result<$res<CustomData>, OCPP2_0_1Error>> + Send,
             {
                 self.on::<$name, F, FF>(callback).await
             }
@@ -79,10 +111,10 @@ macro_rules! ocpp_2_0_1_action {
             pub async fn $wait_for<F, FF>(
                 &self,
                 callback: F,
-            ) -> Result<$req, ClientError<OCPP2_0_1Error>>
+            ) -> Result<$req<CustomData>, ClientError<OCPP2_0_1Error>>
             where
-                F: FnMut($req, Self) -> FF + Send + Sync + 'static,
-                FF: Future<Output = Result<$res, OCPP2_0_1Error>> + Send,
+                F: FnMut($req<CustomData>, Self) -> FF + Send + Sync + 'static,
+                FF: Future<Output = Result<$res<CustomData>, OCPP2_0_1Error>> + Send,
             {
                 self.wait_for::<$name, F, FF>(callback).await
             }

--- a/src/ocpp_2_1/actions.rs
+++ b/src/ocpp_2_1/actions.rs
@@ -3,6 +3,8 @@ use crate::error::ClientError;
 use crate::ocpp_2_1::OCPP2_1Client;
 use crate::ocpp_2_1::error::OCPP2_1Error;
 use core::future::Future;
+use core::marker::PhantomData;
+use ocpp_types::v21::common::CustomData;
 use ocpp_types::v21::{
     AFRRSignalRequest, AFRRSignalResponse, AdjustPeriodicEventStreamRequest,
     AdjustPeriodicEventStreamResponse, AuthorizeRequest, AuthorizeResponse, BatterySwapRequest,
@@ -66,30 +68,45 @@ use ocpp_types::v21::{
     UsePriorityChargingRequest, UsePriorityChargingResponse, VatNumberValidationRequest,
     VatNumberValidationResponse,
 };
+use serde::Serialize;
+use serde::de::DeserializeOwned;
 
-/// Same pattern as `ocpp_2_0_1_action!` (see `src/ocpp_2_0_1/actions.rs`): one marker type
-/// implementing [`Action`] plus `send_x`/`on_x`/`wait_for_x` convenience methods on
+/// Same pattern as `ocpp_2_0_1_action!` (see `src/ocpp_2_0_1/actions.rs`, whose documentation
+/// covers the `customData` type parameter and why the generated methods stay concrete): one
+/// marker type implementing [`Action`] plus `send_x`/`on_x`/`wait_for_x` convenience methods on
 /// [`OCPP2_1Client`], generated from one macro line per action.
 macro_rules! ocpp_2_1_action {
-    ($name:ident, $req:ty, $res:ty, $action:literal, $send:ident, $on:ident, $wait_for:ident) => {
+    ($name:ident, $req:ident, $res:ident, $action:literal, $send:ident, $on:ident, $wait_for:ident) => {
         #[doc = concat!("Marker type for the `", $action, "` action.")]
-        pub struct $name;
+        ///
+        /// `C` is the type of the message's `customData` field, defaulting to the
+        /// specification's [`CustomData`]. Name another to read or write a vendor extension
+        /// through [`Client::call`](crate::Client::call)/[`Client::on`](crate::Client::on), or
+        /// [`NoCustomData`](ocpp_types::NoCustomData) to discard it and pay one byte instead of
+        /// the field's full width at every node of the message.
+        pub struct $name<C = CustomData>(PhantomData<fn() -> C>);
 
-        impl Action for $name {
+        impl<C> Action for $name<C>
+        where
+            C: Serialize + DeserializeOwned + Send + Sync + 'static,
+        {
             const NAME: &'static str = $action;
-            type Request = $req;
-            type Response = $res;
+            type Request = $req<C>;
+            type Response = $res<C>;
         }
 
         impl OCPP2_1Client {
-            pub async fn $send(&self, request: $req) -> Result<$res, ClientError<OCPP2_1Error>> {
+            pub async fn $send(
+                &self,
+                request: $req<CustomData>,
+            ) -> Result<$res<CustomData>, ClientError<OCPP2_1Error>> {
                 self.call::<$name>(request).await
             }
 
             pub async fn $on<F, FF>(&self, callback: F)
             where
-                F: FnMut($req, Self) -> FF + Send + Sync + 'static,
-                FF: Future<Output = Result<$res, OCPP2_1Error>> + Send,
+                F: FnMut($req<CustomData>, Self) -> FF + Send + Sync + 'static,
+                FF: Future<Output = Result<$res<CustomData>, OCPP2_1Error>> + Send,
             {
                 self.on::<$name, F, FF>(callback).await
             }
@@ -98,10 +115,10 @@ macro_rules! ocpp_2_1_action {
             pub async fn $wait_for<F, FF>(
                 &self,
                 callback: F,
-            ) -> Result<$req, ClientError<OCPP2_1Error>>
+            ) -> Result<$req<CustomData>, ClientError<OCPP2_1Error>>
             where
-                F: FnMut($req, Self) -> FF + Send + Sync + 'static,
-                FF: Future<Output = Result<$res, OCPP2_1Error>> + Send,
+                F: FnMut($req<CustomData>, Self) -> FF + Send + Sync + 'static,
+                FF: Future<Output = Result<$res<CustomData>, OCPP2_1Error>> + Send,
             {
                 self.wait_for::<$name, F, FF>(callback).await
             }
@@ -114,23 +131,32 @@ macro_rules! ocpp_2_1_action {
 /// `NotifyPeriodicEventStream`), not a Request/Response pair, and the generated `$on` callback
 /// returns nothing, since the spec forbids replying to a `SEND`.
 macro_rules! ocpp_2_1_send_action {
-    ($name:ident, $payload:ty, $action:literal, $send:ident, $on:ident) => {
+    ($name:ident, $payload:ident, $action:literal, $send:ident, $on:ident) => {
         #[doc = concat!("Marker type for the `", $action, "` SEND message.")]
-        pub struct $name;
+        ///
+        /// `C` is the type of the payload's `customData` field, exactly as for the CALL actions
+        /// above.
+        pub struct $name<C = CustomData>(PhantomData<fn() -> C>);
 
-        impl SendAction for $name {
+        impl<C> SendAction for $name<C>
+        where
+            C: Serialize + DeserializeOwned + Send + Sync + 'static,
+        {
             const NAME: &'static str = $action;
-            type Payload = $payload;
+            type Payload = $payload<C>;
         }
 
         impl OCPP2_1Client {
-            pub async fn $send(&self, payload: $payload) -> Result<(), ClientError<OCPP2_1Error>> {
+            pub async fn $send(
+                &self,
+                payload: $payload<CustomData>,
+            ) -> Result<(), ClientError<OCPP2_1Error>> {
                 self.send_notification::<$name>(payload).await
             }
 
             pub async fn $on<F, FF>(&self, callback: F)
             where
-                F: FnMut($payload, Self) -> FF + Send + Sync + 'static,
+                F: FnMut($payload<CustomData>, Self) -> FF + Send + Sync + 'static,
                 FF: Future<Output = ()> + Send,
             {
                 self.on_notification::<$name, F, FF>(callback).await

--- a/tests/connect_negotiation.rs
+++ b/tests/connect_negotiation.rs
@@ -4,6 +4,7 @@
 #![allow(clippy::result_large_err)]
 use futures::{SinkExt, StreamExt};
 use ocpp_client::{NegotiatedClient, OcppVersion, connect};
+use ocpp_types::OcppTimestamp;
 use ocpp_types::v16::HeartbeatRequest as V16HeartbeatRequest;
 use ocpp_types::v201::HeartbeatRequest;
 use serde_json::{Value, json};
@@ -64,7 +65,10 @@ async fn connect_negotiates_whichever_version_the_server_picks() {
         .send_heartbeat(HeartbeatRequest { custom_data: None })
         .await
         .unwrap();
-    assert_eq!(response.current_time, "2024-01-01T00:00:00Z");
+    assert_eq!(
+        response.current_time,
+        OcppTimestamp::parse_rfc3339("2024-01-01T00:00:00Z").unwrap()
+    );
 
     server.await.unwrap();
 }
@@ -119,7 +123,10 @@ async fn connect_only_offers_the_caller_supplied_versions() {
         _ => panic!("expected the server's ocpp1.6 pick, got a different version"),
     };
     let response = client.send_heartbeat(V16HeartbeatRequest {}).await.unwrap();
-    assert_eq!(response.current_time, "2024-01-01T00:00:00Z");
+    assert_eq!(
+        response.current_time,
+        OcppTimestamp::parse_rfc3339("2024-01-01T00:00:00Z").unwrap()
+    );
 
     server.await.unwrap();
 }

--- a/tests/custom_data_generics.rs
+++ b/tests/custom_data_generics.rs
@@ -1,0 +1,270 @@
+//! 2.x's `customData` extension point, which `ocpp-types` 0.2.0 turned into a type parameter on
+//! every message type.
+//!
+//! The generated `send_*`/`on_*`/`wait_for_*` methods pin that parameter to the specification's
+//! own `CustomData` (a bare `vendorId`), because a generic method would break inference at every
+//! call site that builds a request inline with `custom_data: None` - a defaulted type parameter
+//! does not participate in inference. A deployment with a richer vendor extension therefore goes
+//! through the generic `Client::call`/`Client::on` with the marker type instantiated itself,
+//! which is what this file covers. Version-independent, so 2.0.1 carries the cases and 2.1 gets
+//! one to prove the second macro expands the same way.
+mod common;
+
+use common::fake_transport_pair;
+use ocpp_client::ocpp_2_0_1::{OCPP2_0_1Client, OCPP2_0_1Error};
+use ocpp_client::ocpp_2_1::OCPP2_1Client;
+use ocpp_client::{
+    Action, Client, TokioExecutor, TokioTimer, TransportEvent, TransportSink, TransportStream,
+};
+use ocpp_types::v201::common::{CustomData, ResetEnum, ResetStatusEnum};
+use ocpp_types::v201::{HeartbeatRequest, HeartbeatResponse, ResetRequest, ResetResponse};
+use ocpp_types::{NoCustomData, OcppTimestamp};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::time::Duration;
+
+/// A vendor extension richer than the specification's `vendorId`-only shape - the thing that is
+/// impossible to express through the concrete `send_*` methods.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct AcmeExtension {
+    #[serde(rename = "vendorId")]
+    vendor_id: String,
+    #[serde(rename = "siteId")]
+    site_id: u32,
+}
+
+fn client_pair(timeout: Duration) -> (OCPP2_0_1Client, common::FakeSink, common::FakeSource) {
+    let ((client_sink, client_source), (peer_sink, peer_source)) = fake_transport_pair();
+    let client: OCPP2_0_1Client = Client::from_transport(
+        Box::new(client_sink),
+        Box::new(client_source),
+        timeout,
+        Box::new(TokioExecutor),
+        Box::new(TokioTimer),
+    );
+    (client, peer_sink, peer_source)
+}
+
+async fn recv_frame(peer_source: &mut common::FakeSource) -> Value {
+    match peer_source.recv().await.unwrap() {
+        Some(TransportEvent::Frame(frame)) => serde_json::from_str(&frame).unwrap(),
+        other => panic!("expected a frame, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn call_sends_and_reads_back_a_consumers_own_custom_data_shape() {
+    use ocpp_client::ocpp_2_0_1::Heartbeat;
+
+    let (client, mut peer_sink, mut peer_source) = client_pair(Duration::from_secs(5));
+
+    let call = tokio::spawn(async move {
+        client
+            .call::<Heartbeat<AcmeExtension>>(HeartbeatRequest {
+                custom_data: Some(AcmeExtension {
+                    vendor_id: "com.acme".into(),
+                    site_id: 42,
+                }),
+            })
+            .await
+    });
+
+    let frame = recv_frame(&mut peer_source).await;
+    assert_eq!(frame[2], "Heartbeat");
+    // The whole point: a field the specification's `CustomData` has no room for reaches the wire.
+    assert_eq!(frame[3]["customData"]["siteId"], 42);
+    let message_id = frame[1].as_str().unwrap().to_string();
+
+    let response: HeartbeatResponse<AcmeExtension> = HeartbeatResponse {
+        current_time: OcppTimestamp::parse_rfc3339("2024-01-01T00:00:00Z").unwrap(),
+        custom_data: Some(AcmeExtension {
+            vendor_id: "com.acme".into(),
+            site_id: 7,
+        }),
+    };
+    peer_sink
+        .send(serde_json::to_string(&json!([3, message_id, response])).unwrap())
+        .await
+        .unwrap();
+
+    let response = call.await.unwrap().unwrap();
+    assert_eq!(response.custom_data.unwrap().site_id, 7);
+}
+
+#[tokio::test]
+async fn on_answers_with_a_consumers_own_custom_data_shape() {
+    use ocpp_client::ocpp_2_0_1::Reset;
+
+    let (client, mut peer_sink, mut peer_source) = client_pair(Duration::from_secs(5));
+
+    client
+        .on::<Reset<AcmeExtension>, _, _>(|request, _client| async move {
+            assert_eq!(request.custom_data.unwrap().site_id, 1);
+            Ok::<_, OCPP2_0_1Error>(ResetResponse {
+                custom_data: Some(AcmeExtension {
+                    vendor_id: "com.acme".into(),
+                    site_id: 2,
+                }),
+                status: ResetStatusEnum::Accepted,
+                status_info: None,
+            })
+        })
+        .await;
+
+    let request = json!({
+        "customData": {"vendorId": "com.acme", "siteId": 1},
+        "type": "Immediate",
+    });
+    peer_sink
+        .send(serde_json::to_string(&json!([2, "req-1", "Reset", request])).unwrap())
+        .await
+        .unwrap();
+
+    let response = recv_frame(&mut peer_source).await;
+    assert_eq!(response[0], 3);
+    assert_eq!(response[2]["customData"]["siteId"], 2);
+}
+
+/// The marker's default is this crate's `CustomData`, *not* `ocpp-types`' own `NoCustomData`, so
+/// the turbofish-free spelling keeps the vendor id it kept before 0.4.0 rather than silently
+/// discarding it.
+#[tokio::test]
+async fn the_default_marker_keeps_the_specifications_custom_data() {
+    use ocpp_client::ocpp_2_0_1::Reset;
+
+    let (client, mut peer_sink, mut peer_source) = client_pair(Duration::from_secs(5));
+
+    let call = tokio::spawn(async move {
+        client
+            .call::<Reset>(ResetRequest {
+                custom_data: Some(CustomData {
+                    vendor_id: "com.acme".try_into().unwrap(),
+                }),
+                r#type: ResetEnum::Immediate,
+                evse_id: None,
+            })
+            .await
+    });
+
+    let frame = recv_frame(&mut peer_source).await;
+    assert_eq!(frame[3]["customData"]["vendorId"], "com.acme");
+    let message_id = frame[1].as_str().unwrap().to_string();
+
+    let response = json!({"status": "Accepted", "customData": {"vendorId": "com.acme"}});
+    peer_sink
+        .send(serde_json::to_string(&json!([3, message_id, response])).unwrap())
+        .await
+        .unwrap();
+
+    let response = call.await.unwrap().unwrap();
+    assert_eq!(response.custom_data.unwrap().vendor_id.as_str(), "com.acme");
+}
+
+/// `NoCustomData` is the other end of the trade: it accepts whatever the peer sends and discards
+/// it, for a deployment that would rather not carry the field's width at every node.
+#[tokio::test]
+async fn no_custom_data_accepts_and_discards_what_the_peer_sends() {
+    use ocpp_client::ocpp_2_0_1::Reset;
+
+    let (client, mut peer_sink, mut peer_source) = client_pair(Duration::from_secs(5));
+
+    client
+        .on::<Reset<NoCustomData>, _, _>(|request, _client| async move {
+            // Present, but nothing to read out of it.
+            assert!(request.custom_data.is_some());
+            Ok::<_, OCPP2_0_1Error>(ResetResponse {
+                custom_data: None,
+                status: ResetStatusEnum::Accepted,
+                status_info: None,
+            })
+        })
+        .await;
+
+    let request = json!({
+        "customData": {"vendorId": "com.acme", "siteId": 1},
+        "type": "Immediate",
+    });
+    peer_sink
+        .send(serde_json::to_string(&json!([2, "req-1", "Reset", request])).unwrap())
+        .await
+        .unwrap();
+
+    let response = recv_frame(&mut peer_source).await;
+    assert_eq!(response[0], 3);
+    assert_eq!(response[2]["status"], "Accepted");
+}
+
+/// `ocpp_2_1_action!` expands to the same shape, marker default included.
+#[tokio::test]
+async fn the_2_1_macro_takes_the_parameter_too() {
+    use ocpp_client::ocpp_2_1::Heartbeat;
+    use ocpp_types::v21::HeartbeatRequest as HeartbeatRequest2_1;
+    use ocpp_types::v21::HeartbeatResponse as HeartbeatResponse2_1;
+
+    let ((client_sink, client_source), (mut peer_sink, mut peer_source)) = fake_transport_pair();
+    let client: OCPP2_1Client = Client::from_transport(
+        Box::new(client_sink),
+        Box::new(client_source),
+        Duration::from_secs(5),
+        Box::new(TokioExecutor),
+        Box::new(TokioTimer),
+    );
+
+    let call = tokio::spawn(async move {
+        client
+            .call::<Heartbeat<AcmeExtension>>(HeartbeatRequest2_1 {
+                custom_data: Some(AcmeExtension {
+                    vendor_id: "com.acme".into(),
+                    site_id: 42,
+                }),
+            })
+            .await
+    });
+
+    let frame = recv_frame(&mut peer_source).await;
+    assert_eq!(frame[3]["customData"]["siteId"], 42);
+    let message_id = frame[1].as_str().unwrap().to_string();
+
+    let response: HeartbeatResponse2_1<AcmeExtension> = HeartbeatResponse2_1 {
+        current_time: OcppTimestamp::parse_rfc3339("2024-01-01T00:00:00Z").unwrap(),
+        custom_data: None,
+    };
+    peer_sink
+        .send(serde_json::to_string(&json!([3, message_id, response])).unwrap())
+        .await
+        .unwrap();
+
+    call.await.unwrap().unwrap();
+}
+
+/// The marker types are type-level tags: `Action` requires them to be `Send + Sync + 'static`,
+/// and the `PhantomData<fn() -> C>` in the macro is what keeps that true independently of `C`.
+#[test]
+fn a_marker_is_send_and_sync_whatever_the_custom_data_type_is() {
+    use ocpp_client::ocpp_2_0_1::Reset;
+
+    fn assert_action<A: Action + Send + Sync + 'static>() {}
+
+    // Not `Sync`, and deliberately so - the marker must not inherit it.
+    struct NotSync(#[allow(dead_code)] std::cell::Cell<u32>);
+
+    impl Serialize for NotSync {
+        fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            serializer.serialize_unit()
+        }
+    }
+
+    impl<'de> Deserialize<'de> for NotSync {
+        fn deserialize<D: serde::Deserializer<'de>>(_: D) -> Result<Self, D::Error> {
+            Ok(NotSync(std::cell::Cell::new(0)))
+        }
+    }
+
+    assert_action::<Reset>();
+    assert_action::<Reset<NoCustomData>>();
+    assert_action::<Reset<AcmeExtension>>();
+    // `Reset<NotSync>` is still `Send + Sync` as a *marker*; it just isn't a usable `Action`,
+    // since `Action`'s associated types carry the bounds the payload needs.
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<Reset<NotSync>>();
+}

--- a/tests/ocpp_1_6_bookkeeping.rs
+++ b/tests/ocpp_1_6_bookkeeping.rs
@@ -11,6 +11,7 @@ mod common;
 use common::{PongBehavior, fake_transport_pair, spawn_peer};
 use ocpp_client::ocpp_1_6::{Heartbeat, OCPP1_6Client};
 use ocpp_client::{Client, ClientConfig, ClientError, TokioExecutor, TokioTimer, TransportEvent};
+use ocpp_types::OcppTimestamp;
 use ocpp_types::v16::{HeartbeatRequest, HeartbeatResponse};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -150,7 +151,7 @@ async fn replacing_a_handler_stops_the_previous_handler_task() {
             let _ = &guard;
             async move {
                 Ok(HeartbeatResponse {
-                    current_time: "2024-01-01T00:00:00Z".into(),
+                    current_time: OcppTimestamp::parse_rfc3339("2024-01-01T00:00:00Z").unwrap(),
                 })
             }
         })
@@ -165,7 +166,7 @@ async fn replacing_a_handler_stops_the_previous_handler_task() {
     client
         .on::<Heartbeat, _, _>(|_req, _client| async move {
             Ok(HeartbeatResponse {
-                current_time: "2024-01-01T00:00:00Z".into(),
+                current_time: OcppTimestamp::parse_rfc3339("2024-01-01T00:00:00Z").unwrap(),
             })
         })
         .await;
@@ -197,7 +198,7 @@ async fn the_replacement_handler_is_the_one_that_answers() {
             async move {
                 counter.fetch_add(1, Ordering::SeqCst);
                 Ok(HeartbeatResponse {
-                    current_time: "2024-01-01T00:00:00Z".into(),
+                    current_time: OcppTimestamp::parse_rfc3339("2024-01-01T00:00:00Z").unwrap(),
                 })
             }
         })
@@ -210,7 +211,7 @@ async fn the_replacement_handler_is_the_one_that_answers() {
             async move {
                 counter.fetch_add(1, Ordering::SeqCst);
                 Ok(HeartbeatResponse {
-                    current_time: "2024-01-01T00:00:00Z".into(),
+                    current_time: OcppTimestamp::parse_rfc3339("2024-01-01T00:00:00Z").unwrap(),
                 })
             }
         })
@@ -254,7 +255,7 @@ async fn wait_for_unregisters_so_later_calls_are_not_swallowed() {
             client
                 .wait_for::<Heartbeat, _, _>(|_req, _client| async move {
                     Ok(HeartbeatResponse {
-                        current_time: "2024-01-01T00:00:00Z".into(),
+                        current_time: OcppTimestamp::parse_rfc3339("2024-01-01T00:00:00Z").unwrap(),
                     })
                 })
                 .await

--- a/tests/ocpp_1_6_custom_reconnector.rs
+++ b/tests/ocpp_1_6_custom_reconnector.rs
@@ -11,6 +11,7 @@ use ocpp_client::{
     ConnectOptions, OcppVersion, ReconnectBehavior, ReconnectPolicy, Reconnector, TransportError,
     TransportSink, TransportStream, connect_1_6, websocket_transport,
 };
+use ocpp_types::OcppTimestamp;
 use ocpp_types::v16::HeartbeatRequest;
 use serde_json::{Value, json};
 use std::future::Future;
@@ -123,7 +124,7 @@ async fn a_custom_reconnector_redials_an_address_the_client_was_never_given() {
             .await
             .unwrap()
             .current_time,
-        "2024-01-01T00:00:00Z"
+        OcppTimestamp::parse_rfc3339("2024-01-01T00:00:00Z").unwrap()
     );
     first_server.await.unwrap();
 
@@ -138,7 +139,7 @@ async fn a_custom_reconnector_redials_an_address_the_client_was_never_given() {
             .await
             .unwrap()
             .current_time,
-        "2024-01-01T00:00:00Z"
+        OcppTimestamp::parse_rfc3339("2024-01-01T00:00:00Z").unwrap()
     );
     second_server.await.unwrap();
 }

--- a/tests/ocpp_1_6_custom_tls.rs
+++ b/tests/ocpp_1_6_custom_tls.rs
@@ -8,6 +8,7 @@ use futures::{SinkExt, StreamExt};
 use ocpp_client::rustls::pki_types::PrivatePkcs8KeyDer;
 use ocpp_client::rustls::{ClientConfig, RootCertStore, ServerConfig};
 use ocpp_client::{ConnectOptions, connect_1_6};
+use ocpp_types::OcppTimestamp;
 use ocpp_types::v16::HeartbeatRequest;
 use serde_json::{Value, json};
 use std::sync::Arc;
@@ -77,7 +78,10 @@ async fn connects_over_wss_with_a_custom_root_ca() {
         .await
         .unwrap();
     let response = client.send_heartbeat(HeartbeatRequest {}).await.unwrap();
-    assert_eq!(response.current_time, "2024-01-01T00:00:00Z");
+    assert_eq!(
+        response.current_time,
+        OcppTimestamp::parse_rfc3339("2024-01-01T00:00:00Z").unwrap()
+    );
 
     server.await.unwrap();
 }

--- a/tests/ocpp_1_6_fake_transport.rs
+++ b/tests/ocpp_1_6_fake_transport.rs
@@ -8,7 +8,10 @@ use ocpp_client::{
     Client, ClientError, ProtocolError, TokioExecutor, TokioTimer, TransportEvent, TransportSink,
     TransportStream,
 };
-use ocpp_types::v16::common::{RequestedMessage, TriggerMessageResponseStatus};
+use ocpp_types::OcppTimestamp;
+use ocpp_types::v16::common::{
+    TriggerMessageRequestRequestedMessage, TriggerMessageResponseStatus,
+};
 use ocpp_types::v16::{
     HeartbeatRequest, HeartbeatResponse, TriggerMessageRequest, TriggerMessageResponse,
 };
@@ -46,13 +49,13 @@ async fn call_resolves_on_matching_result() {
     let message_id = frame[1].as_str().unwrap().to_string();
 
     let response = HeartbeatResponse {
-        current_time: chrono::Utc::now().to_rfc3339(),
+        current_time: OcppTimestamp::parse_rfc3339("2024-01-01T00:00:00Z").unwrap(),
     };
     let result_frame = serde_json::to_string(&json!([3, message_id, response])).unwrap();
     peer_sink.send(result_frame).await.unwrap();
 
     let response = call.await.unwrap().unwrap();
-    assert!(!response.current_time.is_empty());
+    assert_eq!(response.current_time.unix_seconds(), 1_704_067_200);
 }
 
 #[tokio::test]
@@ -102,7 +105,7 @@ async fn on_action_answers_a_call_from_the_peer() {
         .await;
 
     let request = TriggerMessageRequest {
-        requested_message: RequestedMessage::Heartbeat,
+        requested_message: TriggerMessageRequestRequestedMessage::Heartbeat,
         connector_id: None,
     };
     let call_frame =

--- a/tests/ocpp_1_6_mtls.rs
+++ b/tests/ocpp_1_6_mtls.rs
@@ -11,6 +11,7 @@ use ocpp_client::rustls::pki_types::{CertificateDer, PrivatePkcs8KeyDer};
 use ocpp_client::rustls::server::WebPkiClientVerifier;
 use ocpp_client::rustls::{ClientConfig, RootCertStore, ServerConfig};
 use ocpp_client::{ConnectOptions, connect_1_6};
+use ocpp_types::OcppTimestamp;
 use ocpp_types::v16::HeartbeatRequest;
 use serde_json::{Value, json};
 use std::sync::Arc;
@@ -92,7 +93,10 @@ async fn connects_over_wss_with_mutual_tls_client_certificate() {
         .await
         .unwrap();
     let response = client.send_heartbeat(HeartbeatRequest {}).await.unwrap();
-    assert_eq!(response.current_time, "2024-01-01T00:00:00Z");
+    assert_eq!(
+        response.current_time,
+        OcppTimestamp::parse_rfc3339("2024-01-01T00:00:00Z").unwrap()
+    );
 
     server.await.unwrap();
 }

--- a/tests/ocpp_1_6_reconnect.rs
+++ b/tests/ocpp_1_6_reconnect.rs
@@ -5,6 +5,7 @@
 #![allow(clippy::result_large_err)]
 use futures::{SinkExt, StreamExt};
 use ocpp_client::{ConnectOptions, ReconnectBehavior, ReconnectPolicy, connect_1_6};
+use ocpp_types::OcppTimestamp;
 use ocpp_types::v16::HeartbeatRequest;
 use serde_json::{Value, json};
 use std::time::Duration;
@@ -66,13 +67,19 @@ async fn client_reconnects_after_the_connection_drops() {
         .unwrap();
 
     let first = client.send_heartbeat(HeartbeatRequest {}).await.unwrap();
-    assert_eq!(first.current_time, "2024-01-01T00:00:00Z");
+    assert_eq!(
+        first.current_time,
+        OcppTimestamp::parse_rfc3339("2024-01-01T00:00:00Z").unwrap()
+    );
 
     // Give the background read loop time to notice the close and redial before we send again.
     tokio::time::sleep(Duration::from_millis(300)).await;
 
     let second = client.send_heartbeat(HeartbeatRequest {}).await.unwrap();
-    assert_eq!(second.current_time, "2024-01-01T00:00:00Z");
+    assert_eq!(
+        second.current_time,
+        OcppTimestamp::parse_rfc3339("2024-01-01T00:00:00Z").unwrap()
+    );
 
     server.await.unwrap();
 }

--- a/tests/ocpp_1_6_reconnect_backoff.rs
+++ b/tests/ocpp_1_6_reconnect_backoff.rs
@@ -13,6 +13,7 @@
 
 use futures::{SinkExt, StreamExt};
 use ocpp_client::{ConnectOptions, ReconnectBehavior, ReconnectPolicy, connect_1_6};
+use ocpp_types::OcppTimestamp;
 use ocpp_types::v16::HeartbeatRequest;
 use serde_json::{Value, json};
 use std::sync::Arc;
@@ -212,7 +213,10 @@ async fn a_connection_that_carried_traffic_resets_the_backoff() {
     .await
     .expect("should have reached the working connection by now")
     .expect("heartbeat should round-trip");
-    assert_eq!(response.current_time, "2024-01-01T00:00:00Z");
+    assert_eq!(
+        response.current_time,
+        OcppTimestamp::parse_rfc3339("2024-01-01T00:00:00Z").unwrap()
+    );
     let traffic_at = tokio::time::Instant::now();
 
     // The first redial *after* that traffic is the one whose delay we care about.

--- a/tests/ocpp_1_6_security_actions.rs
+++ b/tests/ocpp_1_6_security_actions.rs
@@ -1,0 +1,440 @@
+//! The eleven actions the OCPP 1.6 security whitepaper adds on top of 1.6J, which `ocpp-types`
+//! 0.2.0 was the first release to define.
+//!
+//! One round trip each, over the in-memory transport: the four a charge point initiates go out
+//! through `send_*`, and the seven a CSMS initiates come back in through `on_*`. That split is
+//! the thing worth covering per action - the dispatch machinery underneath is already covered by
+//! `tests/ocpp_1_6_fake_transport.rs`, and `tests/action_coverage.rs` guards the wiring existing
+//! at all.
+mod common;
+
+use common::fake_transport_pair;
+use ocpp_client::ocpp_1_6::{OCPP1_6Client, OCPP1_6Error};
+use ocpp_client::{
+    Client, TokioExecutor, TokioTimer, TransportEvent, TransportSink, TransportStream,
+};
+use ocpp_types::OcppTimestamp;
+use ocpp_types::v16::common::{
+    CertificateHashData, CertificateSignedResponseStatus, CertificateType,
+    DeleteCertificateResponseStatus, ExtendedTriggerMessageRequestRequestedMessage,
+    ExtendedTriggerMessageResponseStatus, Firmware, GetInstalledCertificateIdsResponseStatus,
+    GetLogResponseStatus, HashAlgorithm, InstallCertificateResponseStatus, Log,
+    LogStatusNotificationRequestStatus, LogType, SignCertificateResponseStatus,
+    SignedFirmwareStatusNotificationRequestStatus, SignedUpdateFirmwareResponseStatus,
+};
+use ocpp_types::v16::{
+    CertificateSignedRequest, CertificateSignedResponse, DeleteCertificateRequest,
+    DeleteCertificateResponse, ExtendedTriggerMessageRequest, ExtendedTriggerMessageResponse,
+    GetInstalledCertificateIdsRequest, GetInstalledCertificateIdsResponse, GetLogRequest,
+    GetLogResponse, InstallCertificateRequest, InstallCertificateResponse,
+    LogStatusNotificationRequest, LogStatusNotificationResponse, SecurityEventNotificationRequest,
+    SecurityEventNotificationResponse, SignCertificateRequest,
+    SignedFirmwareStatusNotificationRequest, SignedFirmwareStatusNotificationResponse,
+    SignedUpdateFirmwareRequest, SignedUpdateFirmwareResponse,
+};
+use serde_json::{Value, json};
+use std::time::Duration;
+
+fn client_pair() -> (OCPP1_6Client, common::FakeSink, common::FakeSource) {
+    let ((client_sink, client_source), (peer_sink, peer_source)) = fake_transport_pair();
+    let client: OCPP1_6Client = Client::from_transport(
+        Box::new(client_sink),
+        Box::new(client_source),
+        Duration::from_secs(5),
+        Box::new(TokioExecutor),
+        Box::new(TokioTimer),
+    );
+    (client, peer_sink, peer_source)
+}
+
+async fn recv_frame(peer_source: &mut common::FakeSource) -> Value {
+    match peer_source.recv().await.unwrap() {
+        Some(TransportEvent::Frame(frame)) => serde_json::from_str(&frame).unwrap(),
+        other => panic!("expected a frame, got {other:?}"),
+    }
+}
+
+/// Reads the CALL the client just sent, checks its action name, and answers it with `payload`.
+async fn answer_call(
+    peer_sink: &mut common::FakeSink,
+    peer_source: &mut common::FakeSource,
+    action: &str,
+    payload: Value,
+) -> Value {
+    let frame = recv_frame(peer_source).await;
+    assert_eq!(frame[0], 2);
+    assert_eq!(frame[2], action);
+    let message_id = frame[1].as_str().unwrap().to_string();
+    peer_sink
+        .send(serde_json::to_string(&json!([3, message_id, payload])).unwrap())
+        .await
+        .unwrap();
+    frame
+}
+
+/// Sends `payload` as a CALL from the peer and returns the CALLRESULT the client answered with.
+async fn call_the_client(
+    peer_sink: &mut common::FakeSink,
+    peer_source: &mut common::FakeSource,
+    action: &str,
+    payload: Value,
+) -> Value {
+    peer_sink
+        .send(serde_json::to_string(&json!([2, "req-1", action, payload])).unwrap())
+        .await
+        .unwrap();
+    let response = recv_frame(peer_source).await;
+    assert_eq!(response[0], 3);
+    assert_eq!(response[1], "req-1");
+    response
+}
+
+// ---------------------------------------------------------------------------
+// Charge-point-initiated
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn sign_certificate_round_trips() {
+    let (client, mut peer_sink, mut peer_source) = client_pair();
+
+    let call = tokio::spawn(async move {
+        client
+            .send_sign_certificate(SignCertificateRequest {
+                csr: "-----BEGIN CERTIFICATE REQUEST-----".into(),
+            })
+            .await
+    });
+
+    let frame = answer_call(
+        &mut peer_sink,
+        &mut peer_source,
+        "SignCertificate",
+        json!({"status": "Accepted"}),
+    )
+    .await;
+    assert_eq!(frame[3]["csr"], "-----BEGIN CERTIFICATE REQUEST-----");
+
+    let response = call.await.unwrap().unwrap();
+    assert_eq!(response.status, SignCertificateResponseStatus::Accepted);
+}
+
+#[tokio::test]
+async fn security_event_notification_round_trips() {
+    let (client, mut peer_sink, mut peer_source) = client_pair();
+
+    let call = tokio::spawn(async move {
+        client
+            .send_security_event_notification(SecurityEventNotificationRequest {
+                tech_info: None,
+                timestamp: OcppTimestamp::parse_rfc3339("2024-01-01T00:00:00Z").unwrap(),
+                r#type: "SettingSystemTime".try_into().unwrap(),
+            })
+            .await
+    });
+
+    let frame = answer_call(
+        &mut peer_sink,
+        &mut peer_source,
+        "SecurityEventNotification",
+        json!({}),
+    )
+    .await;
+    assert_eq!(frame[3]["type"], "SettingSystemTime");
+    assert_eq!(frame[3]["timestamp"], "2024-01-01T00:00:00Z");
+
+    let _: SecurityEventNotificationResponse = call.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn log_status_notification_round_trips() {
+    let (client, mut peer_sink, mut peer_source) = client_pair();
+
+    let call = tokio::spawn(async move {
+        client
+            .send_log_status_notification(LogStatusNotificationRequest {
+                request_id: Some(7),
+                status: LogStatusNotificationRequestStatus::Uploaded,
+            })
+            .await
+    });
+
+    let frame = answer_call(
+        &mut peer_sink,
+        &mut peer_source,
+        "LogStatusNotification",
+        json!({}),
+    )
+    .await;
+    assert_eq!(frame[3]["status"], "Uploaded");
+    assert_eq!(frame[3]["requestId"], 7);
+
+    let _: LogStatusNotificationResponse = call.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn signed_firmware_status_notification_round_trips() {
+    let (client, mut peer_sink, mut peer_source) = client_pair();
+
+    let call = tokio::spawn(async move {
+        client
+            .send_signed_firmware_status_notification(SignedFirmwareStatusNotificationRequest {
+                request_id: Some(9),
+                status: SignedFirmwareStatusNotificationRequestStatus::InstallVerificationFailed,
+            })
+            .await
+    });
+
+    let frame = answer_call(
+        &mut peer_sink,
+        &mut peer_source,
+        "SignedFirmwareStatusNotification",
+        json!({}),
+    )
+    .await;
+    assert_eq!(frame[3]["status"], "InstallVerificationFailed");
+
+    let _: SignedFirmwareStatusNotificationResponse = call.await.unwrap().unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// CSMS-initiated
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn certificate_signed_is_answered() {
+    let (client, mut peer_sink, mut peer_source) = client_pair();
+
+    client
+        .on_certificate_signed(|request: CertificateSignedRequest, _client| async move {
+            assert!(request.certificate_chain.starts_with("-----BEGIN"));
+            Ok::<_, OCPP1_6Error>(CertificateSignedResponse {
+                status: CertificateSignedResponseStatus::Accepted,
+            })
+        })
+        .await;
+
+    let response = call_the_client(
+        &mut peer_sink,
+        &mut peer_source,
+        "CertificateSigned",
+        json!({"certificateChain": "-----BEGIN CERTIFICATE-----"}),
+    )
+    .await;
+    assert_eq!(response[2]["status"], "Accepted");
+}
+
+#[tokio::test]
+async fn delete_certificate_is_answered() {
+    let (client, mut peer_sink, mut peer_source) = client_pair();
+
+    client
+        .on_delete_certificate(|request: DeleteCertificateRequest, _client| async move {
+            assert_eq!(
+                request.certificate_hash_data.hash_algorithm,
+                HashAlgorithm::SHA256
+            );
+            Ok::<_, OCPP1_6Error>(DeleteCertificateResponse {
+                status: DeleteCertificateResponseStatus::NotFound,
+            })
+        })
+        .await;
+
+    let response = call_the_client(
+        &mut peer_sink,
+        &mut peer_source,
+        "DeleteCertificate",
+        json!({"certificateHashData": {
+            "hashAlgorithm": "SHA256",
+            "issuerKeyHash": "aa",
+            "issuerNameHash": "bb",
+            "serialNumber": "01",
+        }}),
+    )
+    .await;
+    assert_eq!(response[2]["status"], "NotFound");
+}
+
+#[tokio::test]
+async fn extended_trigger_message_is_answered() {
+    let (client, mut peer_sink, mut peer_source) = client_pair();
+
+    client
+        .on_extended_trigger_message(
+            |request: ExtendedTriggerMessageRequest, _client| async move {
+                assert_eq!(
+                    request.requested_message,
+                    ExtendedTriggerMessageRequestRequestedMessage::SignChargePointCertificate
+                );
+                Ok::<_, OCPP1_6Error>(ExtendedTriggerMessageResponse {
+                    status: ExtendedTriggerMessageResponseStatus::Accepted,
+                })
+            },
+        )
+        .await;
+
+    let response = call_the_client(
+        &mut peer_sink,
+        &mut peer_source,
+        "ExtendedTriggerMessage",
+        json!({"requestedMessage": "SignChargePointCertificate"}),
+    )
+    .await;
+    assert_eq!(response[2]["status"], "Accepted");
+}
+
+#[tokio::test]
+async fn get_installed_certificate_ids_is_answered() {
+    let (client, mut peer_sink, mut peer_source) = client_pair();
+
+    client
+        .on_get_installed_certificate_ids(
+            |request: GetInstalledCertificateIdsRequest, _client| async move {
+                assert_eq!(
+                    request.certificate_type,
+                    CertificateType::CentralSystemRootCertificate
+                );
+                Ok::<_, OCPP1_6Error>(GetInstalledCertificateIdsResponse {
+                    certificate_hash_data: Some(vec![CertificateHashData {
+                        hash_algorithm: HashAlgorithm::SHA256,
+                        issuer_key_hash: "aa".try_into().unwrap(),
+                        issuer_name_hash: "bb".try_into().unwrap(),
+                        serial_number: "01".try_into().unwrap(),
+                    }]),
+                    status: GetInstalledCertificateIdsResponseStatus::Accepted,
+                })
+            },
+        )
+        .await;
+
+    let response = call_the_client(
+        &mut peer_sink,
+        &mut peer_source,
+        "GetInstalledCertificateIds",
+        json!({"certificateType": "CentralSystemRootCertificate"}),
+    )
+    .await;
+    assert_eq!(response[2]["status"], "Accepted");
+    assert_eq!(response[2]["certificateHashData"][0]["serialNumber"], "01");
+}
+
+#[tokio::test]
+async fn get_log_is_answered() {
+    let (client, mut peer_sink, mut peer_source) = client_pair();
+
+    client
+        .on_get_log(|request: GetLogRequest, _client| async move {
+            assert_eq!(request.log_type, LogType::SecurityLog);
+            // The `Log` struct is where 1.6's security actions meet the new timestamp type.
+            assert_eq!(
+                request.log.oldest_timestamp,
+                Some(OcppTimestamp::parse_rfc3339("2024-01-01T00:00:00Z").unwrap())
+            );
+            Ok::<_, OCPP1_6Error>(GetLogResponse {
+                filename: Some("security.log".try_into().unwrap()),
+                status: GetLogResponseStatus::Accepted,
+            })
+        })
+        .await;
+
+    let response = call_the_client(
+        &mut peer_sink,
+        &mut peer_source,
+        "GetLog",
+        json!({
+            "log": {
+                "remoteLocation": "https://csms.example/logs",
+                "oldestTimestamp": "2024-01-01T00:00:00Z",
+            },
+            "logType": "SecurityLog",
+            "requestId": 3,
+        }),
+    )
+    .await;
+    assert_eq!(response[2]["status"], "Accepted");
+    assert_eq!(response[2]["filename"], "security.log");
+}
+
+#[tokio::test]
+async fn install_certificate_is_answered() {
+    let (client, mut peer_sink, mut peer_source) = client_pair();
+
+    client
+        .on_install_certificate(|request: InstallCertificateRequest, _client| async move {
+            assert_eq!(
+                request.certificate_type,
+                CertificateType::ManufacturerRootCertificate
+            );
+            Ok::<_, OCPP1_6Error>(InstallCertificateResponse {
+                status: InstallCertificateResponseStatus::Accepted,
+            })
+        })
+        .await;
+
+    let response = call_the_client(
+        &mut peer_sink,
+        &mut peer_source,
+        "InstallCertificate",
+        json!({
+            "certificate": "-----BEGIN CERTIFICATE-----",
+            "certificateType": "ManufacturerRootCertificate",
+        }),
+    )
+    .await;
+    assert_eq!(response[2]["status"], "Accepted");
+}
+
+#[tokio::test]
+async fn signed_update_firmware_is_answered() {
+    let (client, mut peer_sink, mut peer_source) = client_pair();
+
+    client
+        .on_signed_update_firmware(|request: SignedUpdateFirmwareRequest, _client| async move {
+            assert_eq!(request.request_id, 11);
+            assert_eq!(
+                request.firmware.retrieve_date_time,
+                OcppTimestamp::parse_rfc3339("2024-01-01T12:00:00Z").unwrap()
+            );
+            Ok::<_, OCPP1_6Error>(SignedUpdateFirmwareResponse {
+                status: SignedUpdateFirmwareResponseStatus::InvalidCertificate,
+            })
+        })
+        .await;
+
+    let response = call_the_client(
+        &mut peer_sink,
+        &mut peer_source,
+        "SignedUpdateFirmware",
+        json!({
+            "firmware": {
+                "location": "https://csms.example/fw.bin",
+                "retrieveDateTime": "2024-01-01T12:00:00Z",
+                "signature": "sig",
+                "signingCertificate": "-----BEGIN CERTIFICATE-----",
+            },
+            "requestId": 11,
+        }),
+    )
+    .await;
+    assert_eq!(response[2]["status"], "InvalidCertificate");
+}
+
+/// The `Firmware`/`Log` structs are constructible from this crate's side too, not just parsed -
+/// a station that mirrors a `SignedUpdateFirmware` back into its own state needs that.
+#[test]
+fn the_new_common_types_are_constructible() {
+    let firmware = Firmware {
+        install_date_time: None,
+        location: "https://csms.example/fw.bin".try_into().unwrap(),
+        retrieve_date_time: OcppTimestamp::parse_rfc3339("2024-01-01T12:00:00Z").unwrap(),
+        signature: "sig".into(),
+        signing_certificate: "-----BEGIN CERTIFICATE-----".into(),
+    };
+    assert_eq!(firmware.retrieve_date_time.unix_seconds(), 1_704_110_400);
+
+    let log = Log {
+        latest_timestamp: None,
+        oldest_timestamp: None,
+        remote_location: "https://csms.example/logs".try_into().unwrap(),
+    };
+    assert_eq!(log.remote_location.as_str(), "https://csms.example/logs");
+}

--- a/tests/ocpp_1_6_timestamps.rs
+++ b/tests/ocpp_1_6_timestamps.rs
@@ -1,0 +1,167 @@
+//! `dateTime` fields, which `ocpp-types` 0.2.0 changed from strings to `OcppTimestamp`.
+//!
+//! This is a behavioural change, not just a type change: the client now *parses* what the CSMS
+//! sends instead of handing the string through untouched, so what a peer may legally write and
+//! what happens when it writes something illegal are both this crate's problem now. Version
+//! independent - 1.6 carries the cases, exactly like `tests/ocpp_1_6_keepalive.rs`.
+mod common;
+
+use common::fake_transport_pair;
+use ocpp_client::ocpp_1_6::OCPP1_6Client;
+use ocpp_client::{
+    Client, ClientError, TokioExecutor, TokioTimer, TransportEvent, TransportSink, TransportStream,
+};
+use ocpp_types::OcppTimestamp;
+use ocpp_types::v16::HeartbeatRequest;
+use serde_json::{Value, json};
+use std::time::Duration;
+
+fn client_pair() -> (OCPP1_6Client, common::FakeSink, common::FakeSource) {
+    let ((client_sink, client_source), (peer_sink, peer_source)) = fake_transport_pair();
+    let client: OCPP1_6Client = Client::from_transport(
+        Box::new(client_sink),
+        Box::new(client_source),
+        Duration::from_secs(5),
+        Box::new(TokioExecutor),
+        Box::new(TokioTimer),
+    );
+    (client, peer_sink, peer_source)
+}
+
+async fn recv_frame(peer_source: &mut common::FakeSource) -> Value {
+    match peer_source.recv().await.unwrap() {
+        Some(TransportEvent::Frame(frame)) => serde_json::from_str(&frame).unwrap(),
+        other => panic!("expected a frame, got {other:?}"),
+    }
+}
+
+/// Sends a heartbeat and answers it with `current_time` verbatim, returning whatever the call
+/// resolved to.
+async fn heartbeat_answered_with(
+    current_time: &str,
+) -> Result<OcppTimestamp, ClientError<ocpp_client::ocpp_1_6::OCPP1_6Error>> {
+    let (client, mut peer_sink, mut peer_source) = client_pair();
+
+    let call = tokio::spawn(async move { client.send_heartbeat(HeartbeatRequest {}).await });
+
+    let frame = recv_frame(&mut peer_source).await;
+    let message_id = frame[1].as_str().unwrap().to_string();
+    peer_sink
+        .send(
+            serde_json::to_string(&json!([3, message_id, {"currentTime": current_time}])).unwrap(),
+        )
+        .await
+        .unwrap();
+
+    call.await.unwrap().map(|response| response.current_time)
+}
+
+/// OCPP deployments write milliseconds in practice, and the OCPP-J examples do too.
+#[tokio::test]
+async fn a_timestamp_with_milliseconds_keeps_them() {
+    let current_time = heartbeat_answered_with("2013-02-01T20:53:32.486Z")
+        .await
+        .unwrap();
+
+    assert_eq!(current_time.unix_seconds(), 1_359_752_012);
+    assert_eq!(current_time.subsec_nanos(), 486_000_000);
+}
+
+/// RFC 3339 allows any fractional precision, not just three digits.
+#[tokio::test]
+async fn a_timestamp_with_nanosecond_precision_keeps_it() {
+    let current_time = heartbeat_answered_with("2024-01-01T00:00:00.123456789Z")
+        .await
+        .unwrap();
+
+    assert_eq!(current_time.subsec_nanos(), 123_456_789);
+}
+
+/// A CSMS in a non-UTC zone is entitled to write its own offset. The instant is what matters for
+/// equality, and the offset is kept alongside it for anyone re-rendering the value.
+#[tokio::test]
+async fn a_non_utc_offset_names_the_same_instant_and_survives() {
+    let current_time = heartbeat_answered_with("2024-03-01T14:00:00+02:00")
+        .await
+        .unwrap();
+
+    assert_eq!(
+        current_time,
+        OcppTimestamp::parse_rfc3339("2024-03-01T12:00:00Z").unwrap()
+    );
+    assert_eq!(current_time.utc_offset_minutes(), 120);
+}
+
+/// The other side of parsing: a peer that writes something that is not a `dateTime` now fails the
+/// call rather than handing a bad string to the caller.
+#[tokio::test]
+async fn a_malformed_timestamp_fails_the_call_as_a_decode_error() {
+    let error = heartbeat_answered_with("yesterday, about noon")
+        .await
+        .expect_err("a non-RFC-3339 currentTime cannot be decoded");
+
+    assert!(
+        matches!(error, ClientError::Decode(_)),
+        "expected a decode error, got {error:?}"
+    );
+}
+
+/// Same for a well-shaped string that names no real instant.
+#[tokio::test]
+async fn an_impossible_date_fails_the_call_as_a_decode_error() {
+    let error = heartbeat_answered_with("2024-02-30T00:00:00Z")
+        .await
+        .expect_err("February 30th is not an instant");
+
+    assert!(
+        matches!(error, ClientError::Decode(_)),
+        "expected a decode error, got {error:?}"
+    );
+}
+
+/// Outbound, the wire form stays what a CSMS expects to read.
+#[tokio::test]
+async fn an_outgoing_timestamp_is_written_as_rfc_3339() {
+    use ocpp_types::v16::StatusNotificationRequest;
+    use ocpp_types::v16::common::{ErrorCode, StatusNotificationRequestStatus};
+
+    let (client, mut peer_sink, mut peer_source) = client_pair();
+
+    let call = tokio::spawn(async move {
+        client
+            .send_status_notification(StatusNotificationRequest {
+                connector_id: 1,
+                error_code: ErrorCode::NoError,
+                info: None,
+                status: StatusNotificationRequestStatus::Available,
+                timestamp: Some(OcppTimestamp::parse_rfc3339("2024-01-01T00:00:00.250Z").unwrap()),
+                vendor_id: None,
+                vendor_error_code: None,
+            })
+            .await
+    });
+
+    let frame = recv_frame(&mut peer_source).await;
+    assert_eq!(frame[3]["timestamp"], "2024-01-01T00:00:00.250Z");
+
+    let message_id = frame[1].as_str().unwrap().to_string();
+    peer_sink
+        .send(serde_json::to_string(&json!([3, message_id, {}])).unwrap())
+        .await
+        .unwrap();
+    call.await.unwrap().unwrap();
+}
+
+/// The `chrono` feature is this crate's only reason to forward anything to `ocpp-types`' own, so
+/// prove the forwarding reaches the conversions rather than just compiling.
+#[cfg(feature = "chrono")]
+#[test]
+fn the_chrono_feature_converts_both_ways() {
+    use chrono::{DateTime, Utc};
+
+    let now = Utc::now();
+    let timestamp = OcppTimestamp::from(now);
+
+    assert_eq!(timestamp.unix_seconds(), now.timestamp());
+    assert_eq!(DateTime::<Utc>::from(timestamp), now);
+}

--- a/tests/ocpp_1_6_websocket.rs
+++ b/tests/ocpp_1_6_websocket.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::result_large_err)]
 use futures::{SinkExt, StreamExt};
 use ocpp_client::connect_1_6;
+use ocpp_types::OcppTimestamp;
 use ocpp_types::v16::HeartbeatRequest;
 use serde_json::{Value, json};
 use tokio::net::TcpListener;
@@ -44,7 +45,10 @@ async fn heartbeat_round_trips_over_a_real_websocket() {
 
     let client = connect_1_6(&format!("ws://{addr}"), None).await.unwrap();
     let response = client.send_heartbeat(HeartbeatRequest {}).await.unwrap();
-    assert_eq!(response.current_time, "2024-01-01T00:00:00Z");
+    assert_eq!(
+        response.current_time,
+        OcppTimestamp::parse_rfc3339("2024-01-01T00:00:00Z").unwrap()
+    );
 
     server.await.unwrap();
 }

--- a/tests/ocpp_2_0_1_fake_transport.rs
+++ b/tests/ocpp_2_0_1_fake_transport.rs
@@ -8,6 +8,7 @@ use ocpp_client::{
     Client, ClientError, ProtocolError, TokioExecutor, TokioTimer, TransportEvent, TransportSink,
     TransportStream,
 };
+use ocpp_types::OcppTimestamp;
 use ocpp_types::v201::common::{ResetEnum, ResetStatusEnum};
 use ocpp_types::v201::{
     HeartbeatRequest, HeartbeatResponse, ResetRequest, ResetResponse,
@@ -50,15 +51,15 @@ async fn call_resolves_on_matching_result() {
     assert_eq!(frame[2], "Heartbeat");
     let message_id = frame[1].as_str().unwrap().to_string();
 
-    let response = HeartbeatResponse {
-        current_time: chrono::Utc::now().to_rfc3339(),
+    let response: HeartbeatResponse = HeartbeatResponse {
+        current_time: OcppTimestamp::parse_rfc3339("2024-01-01T00:00:00Z").unwrap(),
         custom_data: None,
     };
     let result_frame = serde_json::to_string(&json!([3, message_id, response])).unwrap();
     peer_sink.send(result_frame).await.unwrap();
 
     let response = call.await.unwrap().unwrap();
-    assert!(!response.current_time.is_empty());
+    assert_eq!(response.current_time.unix_seconds(), 1_704_067_200);
 }
 
 #[tokio::test]
@@ -113,7 +114,7 @@ async fn on_action_answers_a_call_from_the_peer() {
         })
         .await;
 
-    let request = ResetRequest {
+    let request: ResetRequest = ResetRequest {
         custom_data: None,
         r#type: ResetEnum::Immediate,
         evse_id: None,
@@ -138,7 +139,7 @@ async fn call_resolves_security_event_notification_now_that_its_wired_up() {
             .send_security_event_notification(SecurityEventNotificationRequest {
                 custom_data: None,
                 tech_info: None,
-                timestamp: chrono::Utc::now().to_rfc3339(),
+                timestamp: OcppTimestamp::parse_rfc3339("2024-01-01T00:00:00Z").unwrap(),
                 r#type: "MemoryExhaustion".try_into().unwrap(),
             })
             .await
@@ -149,7 +150,8 @@ async fn call_resolves_security_event_notification_now_that_its_wired_up() {
     assert_eq!(frame[2], "SecurityEventNotification");
     let message_id = frame[1].as_str().unwrap().to_string();
 
-    let response = SecurityEventNotificationResponse { custom_data: None };
+    let response: SecurityEventNotificationResponse =
+        SecurityEventNotificationResponse { custom_data: None };
     let result_frame = serde_json::to_string(&json!([3, message_id, response])).unwrap();
     peer_sink.send(result_frame).await.unwrap();
 

--- a/tests/ocpp_2_0_1_websocket.rs
+++ b/tests/ocpp_2_0_1_websocket.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::result_large_err)]
 use futures::{SinkExt, StreamExt};
 use ocpp_client::connect_2_0_1;
+use ocpp_types::OcppTimestamp;
 use ocpp_types::v201::HeartbeatRequest;
 use serde_json::{Value, json};
 use tokio::net::TcpListener;
@@ -46,7 +47,10 @@ async fn heartbeat_round_trips_over_a_real_websocket() {
         .send_heartbeat(HeartbeatRequest { custom_data: None })
         .await
         .unwrap();
-    assert_eq!(response.current_time, "2024-01-01T00:00:00Z");
+    assert_eq!(
+        response.current_time,
+        OcppTimestamp::parse_rfc3339("2024-01-01T00:00:00Z").unwrap()
+    );
 
     server.await.unwrap();
 }

--- a/tests/ocpp_2_1_fake_transport.rs
+++ b/tests/ocpp_2_1_fake_transport.rs
@@ -8,6 +8,7 @@ use ocpp_client::{
     Client, ClientError, ProtocolError, TokioExecutor, TokioTimer, TransportEvent, TransportSink,
     TransportStream,
 };
+use ocpp_types::OcppTimestamp;
 use ocpp_types::v21::common::{
     ChargingProfileStatusEnum, ChargingScheduleUpdate, DERControlEnum, DERControlStatusEnum,
     DisplayMessageStatusEnum, MessageContent, MessageFormatEnum, MessageInfo, MessagePriorityEnum,
@@ -57,15 +58,15 @@ async fn call_resolves_on_matching_result() {
     assert_eq!(frame[2], "Heartbeat");
     let message_id = frame[1].as_str().unwrap().to_string();
 
-    let response = HeartbeatResponse {
+    let response: HeartbeatResponse = HeartbeatResponse {
         custom_data: None,
-        current_time: chrono::Utc::now().to_rfc3339(),
+        current_time: OcppTimestamp::parse_rfc3339("2024-01-01T00:00:00Z").unwrap(),
     };
     let result_frame = serde_json::to_string(&json!([3, message_id, response])).unwrap();
     peer_sink.send(result_frame).await.unwrap();
 
     let response = call.await.unwrap().unwrap();
-    assert!(!response.current_time.is_empty());
+    assert_eq!(response.current_time.unix_seconds(), 1_704_067_200);
 }
 
 #[tokio::test]
@@ -120,7 +121,7 @@ async fn on_action_answers_a_call_from_the_peer() {
         })
         .await;
 
-    let request = ResetRequest {
+    let request: ResetRequest = ResetRequest {
         custom_data: None,
         r#type: ResetEnum::Immediate,
         evse_id: None,
@@ -144,7 +145,7 @@ async fn call_resolves_notify_report_now_that_its_wired_up() {
         client
             .send_notify_report(NotifyReportRequest {
                 custom_data: None,
-                generated_at: "2024-01-01T00:00:00Z".to_string(),
+                generated_at: OcppTimestamp::parse_rfc3339("2024-01-01T00:00:00Z").unwrap(),
                 report_data: None,
                 request_id: 1,
                 seq_no: 0,
@@ -158,7 +159,7 @@ async fn call_resolves_notify_report_now_that_its_wired_up() {
     assert_eq!(frame[2], "NotifyReport");
     let message_id = frame[1].as_str().unwrap().to_string();
 
-    let response = NotifyReportResponse { custom_data: None };
+    let response: NotifyReportResponse = NotifyReportResponse { custom_data: None };
     let result_frame = serde_json::to_string(&json!([3, message_id, response])).unwrap();
     peer_sink.send(result_frame).await.unwrap();
 
@@ -188,7 +189,7 @@ async fn call_resolves_trigger_message_now_that_its_wired_up() {
     assert_eq!(frame[2], "TriggerMessage");
     let message_id = frame[1].as_str().unwrap().to_string();
 
-    let response = TriggerMessageResponse {
+    let response: TriggerMessageResponse = TriggerMessageResponse {
         custom_data: None,
         status: TriggerMessageStatusEnum::Accepted,
         status_info: None,
@@ -213,7 +214,7 @@ async fn call_resolves_set_display_message_now_that_its_wired_up() {
                     end_date_time: None,
                     id: 1,
                     message: MessageContent {
-                        content: "Hello".try_into().unwrap(),
+                        content: "Hello".into(),
                         custom_data: None,
                         format: MessageFormatEnum::ASCII,
                         language: None,
@@ -233,7 +234,7 @@ async fn call_resolves_set_display_message_now_that_its_wired_up() {
     assert_eq!(frame[2], "SetDisplayMessage");
     let message_id = frame[1].as_str().unwrap().to_string();
 
-    let response = SetDisplayMessageResponse {
+    let response: SetDisplayMessageResponse = SetDisplayMessageResponse {
         custom_data: None,
         status: DisplayMessageStatusEnum::Accepted,
         status_info: None,
@@ -265,7 +266,7 @@ async fn call_resolves_get_der_control_now_that_its_wired_up() {
     assert_eq!(frame[2], "GetDERControl");
     let message_id = frame[1].as_str().unwrap().to_string();
 
-    let response = GetDERControlResponse {
+    let response: GetDERControlResponse = GetDERControlResponse {
         custom_data: None,
         status: DERControlStatusEnum::Accepted,
         status_info: None,
@@ -304,7 +305,7 @@ async fn call_resolves_set_der_control_now_that_its_wired_up() {
     assert_eq!(frame[2], "SetDERControl");
     let message_id = frame[1].as_str().unwrap().to_string();
 
-    let response = SetDERControlResponse {
+    let response: SetDERControlResponse = SetDERControlResponse {
         custom_data: None,
         status: DERControlStatusEnum::Accepted,
         status_info: None,
@@ -349,7 +350,7 @@ async fn call_resolves_update_dynamic_schedule_now_that_its_wired_up() {
     assert_eq!(frame[2], "UpdateDynamicSchedule");
     let message_id = frame[1].as_str().unwrap().to_string();
 
-    let response = UpdateDynamicScheduleResponse {
+    let response: UpdateDynamicScheduleResponse = UpdateDynamicScheduleResponse {
         custom_data: None,
         status: ChargingProfileStatusEnum::Accepted,
         status_info: None,
@@ -380,7 +381,7 @@ async fn send_notify_periodic_event_stream_writes_a_send_frame_and_does_not_wait
     let (client, mut peer_sink, mut peer_source) = client_pair(Duration::from_secs(5));
 
     let payload = NotifyPeriodicEventStream {
-        basetime: "2024-08-27T12:30:40Z".to_string(),
+        basetime: OcppTimestamp::parse_rfc3339("2024-08-27T12:30:40Z").unwrap(),
         custom_data: None,
         data: Vec::new(),
         id: 123,
@@ -413,9 +414,9 @@ async fn send_notify_periodic_event_stream_writes_a_send_frame_and_does_not_wait
     assert_eq!(next_frame[0], 2);
     assert_eq!(next_frame[2], "Heartbeat");
     let message_id = next_frame[1].as_str().unwrap().to_string();
-    let response = HeartbeatResponse {
+    let response: HeartbeatResponse = HeartbeatResponse {
         custom_data: None,
-        current_time: chrono::Utc::now().to_rfc3339(),
+        current_time: OcppTimestamp::parse_rfc3339("2024-01-01T00:00:00Z").unwrap(),
     };
     peer_sink
         .send(serde_json::to_string(&json!([3, message_id, response])).unwrap())

--- a/tests/ocpp_2_1_websocket.rs
+++ b/tests/ocpp_2_1_websocket.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::result_large_err)]
 use futures::{SinkExt, StreamExt};
 use ocpp_client::connect_2_1;
+use ocpp_types::OcppTimestamp;
 use ocpp_types::v21::HeartbeatRequest;
 use serde_json::{Value, json};
 use tokio::net::TcpListener;
@@ -46,7 +47,10 @@ async fn heartbeat_round_trips_over_a_real_websocket() {
         .send_heartbeat(HeartbeatRequest { custom_data: None })
         .await
         .unwrap();
-    assert_eq!(response.current_time, "2024-01-01T00:00:00Z");
+    assert_eq!(
+        response.current_time,
+        OcppTimestamp::parse_rfc3339("2024-01-01T00:00:00Z").unwrap()
+    );
 
     server.await.unwrap();
 }


### PR DESCRIPTION
Tracks the upstream `ocpp-types` 0.2.0 release, out today. The engine needed no changes at all — `client.rs`, `envelope.rs`, `transport.rs`, `error.rs`, `runtime.rs` and `sync.rs` compiled against the new dependency untouched, as they did for the 2.0.1 and 2.1 ports. Everything here follows from four upstream changes.

## Timestamps

Every `dateTime` field is `ocpp_types::OcppTimestamp` instead of `String` — 16 bytes rather than the 1024 an unbounded string reserved, no allocator, and comparable. That makes it a behaviour change twice over:

- the client **parses** timestamps now, so a malformed one from the CSMS fails the call as `ClientError::Decode` instead of reaching the caller as a bad string;
- the value is an **instant**, so two timestamps naming the same moment in different UTC offsets compare equal.

Fractional seconds of any precision and non-UTC offsets both survive a round trip. `tests/ocpp_1_6_timestamps.rs` pins all of it; the other ~30 sites in `tests/`, `benches/` and `examples/` are mechanical.

## customData

2.0.1 and 2.1 message types gained a type parameter for the extension point, defaulting upstream to a zero-sized `NoCustomData` that accepts and discards. Taking that default would have silently downgraded every 2.x caller, so the action markers carry the parameter themselves — `Reset<C = CustomData>` — defaulting to the specification's own shape. A deployment with a richer vendor extension now names its own type:

```rust
let response = client.call::<Reset<AcmeExtension>>(request).await?;
```

which previously meant hand-writing an `Action` impl.

The generated `send_*`/`on_*`/`wait_for_*` methods stay concrete deliberately: a generic method loses inference at every call site that builds a request inline with `custom_data: None`, since a defaulted type parameter does not participate in inference, and that would tax the common path to serve the rare one. Two mechanical consequences — `$req`/`$res` are `ident` fragments now, because a `ty` fragment cannot take generic arguments, and the marker holds `PhantomData<fn() -> C>` so it stays `Send + Sync` (which `Action` requires of the marker) whatever `C` is. Covered by `tests/custom_data_generics.rs`.

## OCPP 1.6 security actions

`ocpp-types` 0.2.0 is the first release to define the eleven security-whitepaper actions, so `action_coverage.rs` failed the moment the dependency was bumped, listing exactly those eleven — which is what that test exists for. One macro line each, taking 1.6 from 28 wired-up actions to **39**; 2.0.1 (64) and 2.1 (91) are unchanged. `tests/ocpp_1_6_security_actions.rs` covers a round trip apiece, split by who initiates.

## Breaking changes for consumers

- every `dateTime` field is `OcppTimestamp` — build with `OcppTimestamp::parse_rfc3339(..)`, compare against a parsed value;
- 2.x requests/responses built in a `let` binding with no expected type need an annotation (`let request: ResetRequest = ..`);
- `v16::common::RequestedMessage` → `TriggerMessageRequestRequestedMessage` (renamed upstream to make room for the `ExtendedTriggerMessage` variant of the same idea);
- 48 2.x fields whose length the specification delegates to a configuration variable — certificates, chains, CSRs, OCSP results, `MessageContent.content` — moved from `heapless::String<N>` to `String`, so construction drops `try_into().unwrap()`.

## Also

An optional `chrono` feature forwarding to `ocpp-types`' own, for `OcppTimestamp` ↔ `chrono::DateTime` interop; chrono never touches the wire path. The CI test job runs `--features test,chrono` since the gated case in `tests/ocpp_1_6_timestamps.rs` is the feature's only coverage.

Version bumped to **0.4.0**. `MIGRATION_OCPP_TYPES.md` gains a section on this migration alongside the original `rust-ocpp` one.

## Verification

Every CI job's exact command, run locally: `fmt`; `clippy --all-targets --all-features -D warnings`; `cargo build` plus the suite under both `--features test` and `--features test,chrono`; the three `no_std`+`alloc` lib proofs and the no-tokio build; the `embedded` job's four commands against `thumbv7em-none-eabihf` (the board firmware's single `.text` alignment warning is pre-existing, see `MIGRATION_OCPP_TYPES.md`); `cargo +1.87 check --lib --all-features` for MSRV; benches compile; `cargo doc --all-features` clean.

The new 1.6 action tests were written first and confirmed failing — 11 missing methods — before the macro lines went in, per the repo's TDD rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xu7evjtyZw36tsypRHwDaQ