### PR TITLE
Prepare 0.4.0: date the changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Notable changes per release. Dates are release dates on crates.io.
 This file starts at 0.2.0; earlier releases (0.1.x, a per-version tokio-hardwired design that
 predates the current generic engine) are covered by git history only.
 
-## 0.4.0 - unreleased
+## 0.4.0 - 2026-08-08
 
 Tracks `ocpp-types` 0.2.0. Everything below follows from that release; the engine itself
 (`src/client.rs`, `envelope.rs`, `transport.rs`) needed no changes at all.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,7 @@ Guidance for Claude Code (claude.ai/code) working in this repository.
 ## Project overview
 
 `ocpp-client` implements the **charge point** (client) side of OCPP — the network/protocol layer
-only, not charging logic or hardware control. Current version `0.4.0` (unreleased; 0.3.0 is the
-newest on crates.io). Pre-1.0 and still moving: 0.3.0 broke `TransportSink`/`TransportStream`,
+only, not charging logic or hardware control. Current version `0.4.0`, the newest on crates.io. Pre-1.0 and still moving: 0.3.0 broke `TransportSink`/`TransportStream`,
 `ReconnectPolicy` and `ConnectOptions`' defaults, and 0.4.0 breaks every `dateTime` field's type
 and adds a type parameter to the 2.x message types (see below).
 

--- a/PRODUCTION_READINESS.md
+++ b/PRODUCTION_READINESS.md
@@ -67,7 +67,7 @@ per-crate READMEs are specifically about the **embedded** satellite crates
    and `::on_notify_periodic_event_stream_fires_and_never_sends_a_reply`, the latter also
    asserting the client never auto-replies to a received SEND.
 
-5. **Versioning/release.** Crate is `0.4.0` (unreleased; 0.3.0 is the newest on crates.io). The
+5. **Versioning/release.** Crate is `0.4.0`, the newest on crates.io. The
    git-fork dependency blocker is long gone - `ocpp-types` is a real crates.io release (`0.2.0`),
    not a git dependency. `ocpp-types` itself is still early (`0.2.x`, same org as the old
    `rust-ocpp` fork - see `MIGRATION_OCPP_TYPES.md`'s Risk section for a codegen bug found and


### PR DESCRIPTION
Dates the `0.4.0` changelog section and drops the matching `unreleased` markers from `CLAUDE.md` and `PRODUCTION_READINESS.md`.

Not bookkeeping: the release workflow's guard explicitly fails a tag whose `CHANGELOG.md` section still reads `## <version> - unreleased`, so `v0.4.0` cannot be pushed until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xu7evjtyZw36tsypRHwDaQ