### PR TITLE
Stop the release job's cache cleanup erroring on the unpacked package

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -106,6 +106,19 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: cargo publish
 
+      # Both publish steps unpack the crate into target/package/<name>-<version>/ to verify it,
+      # which puts a copy of this repo's `tests/` directory *inside* target/. rust-cache's
+      # post-job cleanup walks target/, treats any directory named `tests` as trybuild/macrotest
+      # scratch space, and opens `tests/target` and `tests/trybuild` inside it - neither of which
+      # exists here. Those two calls are not awaited upstream, so the rejections escape their
+      # try/catch and land as ##[error] annotations on a job that actually succeeded (see the
+      # v0.4.0 run). Nothing downstream wants the unpacked copy, so dropping it before the post
+      # step runs removes the noise at the source. `always()` so a failed publish is just as
+      # quiet.
+      - name: Drop the unpacked package copy before the cache post-step walks it
+        if: always()
+        run: rm -rf target/package
+
   github-release:
     name: GitHub Release
     needs: [guard, publish]


### PR DESCRIPTION
The [v0.4.0 release run](https://github.com/flowionab/ocpp-client/actions/runs/31272985999) finished green but carried four `##[error]` annotations on the publish job, which reads as a failed release at a glance.

## Where they come from

Not from cargo — from `Swatinem/rust-cache`'s post-job cleanup. Both publish steps unpack the crate into `target/package/ocpp-client-<version>/` to verify it, which puts a copy of this repo's `tests/` directory *inside* `target/`. rust-cache walks `target/` and, per `cleanup.ts`:

```ts
const isProfile = dirent.name === "tests" || ...

if (path.basename(profileDir) === "tests") {
  try { cleanTargetDir(path.join(profileDir, "target"), ...) } catch {}     // not awaited
  try { cleanTargetDir(path.join(profileDir, "trybuild"), ...) } catch {}   // not awaited
```

it assumes any directory named `tests` is trybuild/macrotest scratch space and opens `tests/target` and `tests/trybuild` inside it. Neither exists here, so both throw `ENOENT`. The `try/catch` doesn't catch them because the calls aren't awaited, so the rejections escape and the action reports them as errors on a job that succeeded.

Reproduced locally: `cargo package` leaves `target/package/ocpp-client-0.4.0/tests` with no `target` or `trybuild` inside it — exactly the pair of `opendir` calls that threw.

## The fix

Nothing downstream wants the unpacked copy — it's rebuilt from the tarball on every run — so removing it after the publish steps takes the trigger away rather than muting the symptom. `if: always()`, so a failed publish is just as quiet.

Deliberately **not** `cache-targets: false`: `save.ts` calls `cleanTargetDir` unconditionally, whether or not the target directory is cached, so that wouldn't have helped.

## Verification

The release pipeline's `workflow_dispatch` rehearsal path can't exercise this right now — its guard fails once the manifest version exists on crates.io, which 0.4.0 now does. So this is verified by the local `cargo package` repro above plus a YAML parse, and it will show up for real on the next tag. Worth a glance at the next release run's annotations to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xu7evjtyZw36tsypRHwDaQ